### PR TITLE
Implement SR Kalman filter and smoke HMC sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # cw2017-hmc-gibbs
 
+## How to run smoke
+
+Execute the smoke-test Gibbs sweep with:
+
+```bash
+python -m scripts.run_gibbs --smoke --chains 4 --seed 0
+```
+
 A reproducible, typed JAX scaffold for the Hamiltonian Monte Carlo (HMC) in Gibbs sampler
 outlined in Creal & Wu (2017, *International Economic Review*). The package emphasises
 square-root Kalman filtering, Durbin–Koopman simulation smoothing, and ChEES-tuned dynamic

--- a/scripts/run_gibbs.py
+++ b/scripts/run_gibbs.py
@@ -5,14 +5,21 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import sys
+from typing import Dict
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = PROJECT_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
+from cw2017.utils import jax_setup  # noqa: F401
+
+import jax
+import jax.numpy as jnp
+
 from cw2017 import config as app_config
 from cw2017.data import datasets
+from cw2017.reporting import save_results, summarize
 from cw2017.samplers import gibbs
 from cw2017.utils import rng as rng_utils
 
@@ -22,7 +29,59 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--config", type=Path, default=Path("configs/defaults.yaml"))
     parser.add_argument("--chains", type=int, default=None)
     parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--smoke", action="store_true", help="run the block-3a smoke sweep")
     return parser.parse_args()
+
+
+def _make_smoke_data(rng_key: jax.Array, T: int, d_state: int, d_y: int, d_m: int) -> Dict[str, jnp.ndarray]:
+    key_y, key_m, key_h = jax.random.split(rng_key, 3)
+    y_t = jax.random.normal(key_y, (T, d_y), dtype=jnp.float64)
+    m_t = jax.random.normal(key_m, (T, d_m), dtype=jnp.float64)
+    h_t = jax.random.normal(key_h, (T, d_state), dtype=jnp.float64)
+    params = {
+        "a0": jnp.zeros(d_state, dtype=jnp.float64),
+        "S0": jnp.eye(d_state, dtype=jnp.float64) * 0.3,
+        "theta": jnp.zeros(d_state, dtype=jnp.float64),
+    }
+    return {"y_t": y_t, "m_t": m_t, "fixed": {"h_t": h_t}, "params": params}
+
+
+def run_smoke(cfg: app_config.AppConfig, rng_key: jax.Array) -> None:
+    chains = cfg.run.chains
+    theta_dim = 4
+    warmup_cfg = {
+        "num_warmup_steps": 50,
+        "target_accept": 0.651,
+        "jitter_amount": 0.9,
+        "decay_rate": 0.5,
+        "adam_lr": 0.02,
+        "initial_step_size": 0.25,
+    }
+
+    data = _make_smoke_data(rng_key, T=50, d_state=4, d_y=3, d_m=2)
+    theta0_key, rng_key = jax.random.split(rng_key)
+    theta0 = 0.1 * jax.random.normal(theta0_key, (chains, theta_dim), dtype=jnp.float64)
+    state = gibbs.SmokeState(theta_block3a=theta0)
+
+    cfg_dict = {"warmup": warmup_cfg}
+    rng_key, state, metrics = gibbs.run_smoke_sweeps(rng_key, state, cfg_dict, data, num_sweeps=5)
+
+    run_id = save_results.build_run_id(cfg.run.run_id_prefix)
+    summary_dir = save_results.prepare_run_directory(Path(cfg.run.results_dir), run_id)
+    summarize.write_summary(summary_dir, metrics)
+    save_results.write_metadata(
+        summary_dir,
+        {
+            "run_id": run_id,
+            "chains": cfg.run.chains,
+            "seed": cfg.run.seed,
+        },
+    )
+
+    tuned = state.diagnostics_3a or {}
+    epsilon = tuned.get("final_step_size", float("nan"))
+    traj = tuned.get("final_trajectory_length", float("nan"))
+    print(f"[smoke] tuned step size: {float(epsilon):.4f}; trajectory length: {float(traj):.4f}")
 
 
 def main() -> None:
@@ -35,6 +94,10 @@ def main() -> None:
 
     rng_manager = rng_utils.RNGManager(config.run.seed)
     rng_key = rng_manager.key
+
+    if args.smoke:
+        run_smoke(config, rng_key)
+        return
 
     if config.data.synthetic:
         datasets.load_synthetic(seed=config.run.seed)

--- a/src/cw2017/kalman/sr_kf.py
+++ b/src/cw2017/kalman/sr_kf.py
@@ -1,46 +1,182 @@
-"""Square-root Kalman filter scaffold.
+"""Square-root Kalman filter implementation used across the sampler.
 
-TODOs:
-- assemble measurement and transition matrices from ``params``
-- implement Joseph-form covariance updates in log-domain
-- propagate work-unit accounting hooks for each SR-KF evaluation
+The filter follows a numerically robust formulation that operates on
+Cholesky factors instead of full covariance matrices. This avoids forming
+matrix inverses explicitly and keeps the updates stable even when the system
+is ill conditioned.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Mapping, Tuple
 
 import jax.numpy as jnp
+import jax.scipy.linalg as jsp
 from jax import lax
 
 from ..typing import Array
 
+_JITTER = 1e-10
+_LOG_2PI = jnp.log(2.0 * jnp.pi)
 
-def sr_kf_loglik(params: Any, h_t: Array, y_t: Array, m_t: Array) -> Tuple[jnp.float64, Dict[str, Array]]:
-    """Run a square-root Kalman filter and return the log-likelihood.
 
-    This stub focuses on array plumbing so unit tests can verify shapes and NaN guards.
-    The actual implementation will propagate square-root factors and innovations.
+def symmetrize_psd(matrix: Array) -> Array:
+    """Symmetrise ``matrix`` ensuring the result remains PSD."""
+
+    return (matrix + matrix.T) * 0.5
+
+
+def _qr_lower(stack: Array) -> Array:
+    """Return a lower-triangular Cholesky factor via QR decomposition."""
+
+    _, r_mat = jnp.linalg.qr(stack.T, mode="reduced")
+    sqrt_factor = r_mat.T
+    diag = jnp.diag(sqrt_factor)
+    sign = jnp.where(diag < 0.0, -1.0, 1.0)
+    return sqrt_factor * sign
+
+
+def sr_predict(S_prev: Array, F_t: Array, Q_chol_t: Array) -> Array:
+    """Predictive square-root covariance update."""
+
+    q_aug = Q_chol_t + _JITTER * jnp.eye(Q_chol_t.shape[0], dtype=S_prev.dtype)
+    fs = F_t @ S_prev
+    stacked = jnp.concatenate([fs, q_aug], axis=1)
+    return _qr_lower(stacked)
+
+
+def sr_update(
+    a_pred: Array,
+    S_pred: Array,
+    H_t: Array,
+    R_chol_t: Array,
+    innovation: Array,
+) -> Tuple[Array, Array, Array, jnp.float64]:
+    """Measurement update returning posterior mean/covariance and log-lik increment."""
+
+    r_aug = R_chol_t + _JITTER * jnp.eye(R_chol_t.shape[0], dtype=S_pred.dtype)
+    HP = H_t @ S_pred
+    stacked = jnp.concatenate([HP, r_aug], axis=1)
+    S_yy = _qr_lower(stacked)
+
+    solved_innov = jsp.solve_triangular(S_yy, innovation, lower=True)
+    quad_form = jnp.dot(solved_innov, solved_innov)
+    log_det = 2.0 * jnp.sum(jnp.log(jnp.clip(jnp.diag(S_yy), min=_JITTER)))
+    obs_dim = innovation.shape[0]
+    loglik_inc = -0.5 * (obs_dim * _LOG_2PI + log_det + quad_form)
+
+    PHt = S_pred @ HP.T
+    tmp = jsp.solve_triangular(S_yy, PHt.T, lower=True)
+    gain_t = jsp.solve_triangular(S_yy.T, tmp, lower=False)
+    kalman_gain = gain_t.T
+
+    posterior_mean = a_pred + kalman_gain @ innovation
+    innovation_effect = kalman_gain @ HP
+    gain_noise = kalman_gain @ r_aug
+    stack_post = jnp.concatenate([S_pred - innovation_effect, gain_noise], axis=1)
+    posterior_sqrt = _qr_lower(stack_post)
+    return posterior_mean, posterior_sqrt, S_yy, loglik_inc
+
+
+def _get_field(container: Any, name: str) -> Any:
+    if isinstance(container, Mapping):
+        return container[name]
+    return getattr(container, name)
+
+
+def _get_builder(params: Any, name: str) -> Any:
+    fns = _get_field(params, "fns")
+    if isinstance(fns, Mapping):
+        return fns[name]
+    return getattr(fns, name)
+
+
+def sr_kf_loglik(
+    params: Any,
+    h_t: Array,
+    y_t: Array,
+    m_t: Array,
+) -> Tuple[jnp.float64, Dict[str, Array]]:
+    """Run a numerically stable SR-Kalman filter.
+
+    Parameters
+    ----------
+    params:
+        Container with ``a0``, ``S0`` and callable builders ``build_HR`` and ``build_FQ``.
+    h_t, y_t, m_t:
+        Time series inputs with leading dimension ``T``.
     """
 
     y_t = jnp.asarray(y_t, dtype=jnp.float64)
-    T, obs_dim = y_t.shape
     h_t = jnp.asarray(h_t, dtype=jnp.float64)
     m_t = jnp.asarray(m_t, dtype=jnp.float64)
 
-    def step(carry: Array, inputs: Tuple[Array, Array, Array]) -> Tuple[Array, Array]:
-        _, y_obs, _ = inputs
-        innovation = y_obs - carry
-        new_state = jnp.zeros_like(carry)
-        return new_state, innovation
+    a_prev = jnp.asarray(_get_field(params, "a0"), dtype=jnp.float64)
+    S_prev = jnp.asarray(_get_field(params, "S0"), dtype=jnp.float64)
 
-    initial_mean = jnp.zeros(obs_dim, dtype=jnp.float64)
-    _, innovations = lax.scan(step, initial_mean, (h_t, y_t, m_t))
-    loglik = jnp.array(0.0, dtype=jnp.float64)
-    aux: Dict[str, Array] = {"innovations": innovations}
-    if not jnp.all(jnp.isfinite(innovations)):
-        raise FloatingPointError("Non-finite innovations encountered in SR-KF stub")
+    build_HR = _get_builder(params, "build_HR")
+    build_FQ = _get_builder(params, "build_FQ")
+
+    time_index = jnp.arange(y_t.shape[0])
+
+    def step(carry, inputs):
+        mean_prev, sqrt_prev = carry
+        t_idx, h_curr, y_curr, m_curr = inputs
+        H_t, R_chol_t = build_HR(t_idx, params, h_curr, m_curr)
+        F_t, Q_chol_t = build_FQ(t_idx, params, h_curr, m_curr)
+
+        H_t = jnp.asarray(H_t, dtype=jnp.float64)
+        R_chol_t = jnp.asarray(R_chol_t, dtype=jnp.float64)
+        F_t = jnp.asarray(F_t, dtype=jnp.float64)
+        Q_chol_t = jnp.asarray(Q_chol_t, dtype=jnp.float64)
+
+        a_pred = F_t @ mean_prev
+        S_pred = sr_predict(sqrt_prev, F_t, Q_chol_t)
+        innovation = y_curr - H_t @ a_pred
+        a_post, S_post, S_yy, ll_inc = sr_update(a_pred, S_pred, H_t, R_chol_t, innovation)
+
+        finite_flags = jnp.array(
+            [
+                jnp.all(jnp.isfinite(arr))
+                for arr in (a_pred, S_pred, innovation, a_post, S_post, S_yy)
+            ],
+            dtype=jnp.bool_,
+        )
+        nan_flag = jnp.logical_not(jnp.all(finite_flags))
+
+        outputs = {
+            "filtered_mean": a_post,
+            "filtered_sqrt": S_post,
+            "innovation": innovation,
+            "innovation_sqrt": S_yy,
+            "loglik": ll_inc,
+            "nan_flag": nan_flag,
+        }
+        return (a_post, S_post), outputs
+
+    (_, _), outputs = lax.scan(
+        step,
+        (a_prev, S_prev),
+        (time_index, h_t, y_t, m_t),
+    )
+
+    loglik = jnp.sum(outputs["loglik"], dtype=jnp.float64)
+    nan_detected = jnp.any(outputs["nan_flag"])
+    loglik = jnp.where(nan_detected, -jnp.inf, loglik)
+
+    aux: Dict[str, Array] = {
+        "filtered_means": outputs["filtered_mean"],
+        "filtered_sqrt_covs": outputs["filtered_sqrt"],
+        "innovations": outputs["innovation"],
+        "innovation_sqrt": outputs["innovation_sqrt"],
+        "nan_detected": nan_detected,
+    }
     return loglik, aux
 
 
-__all__ = ["sr_kf_loglik"]
+__all__ = [
+    "sr_kf_loglik",
+    "symmetrize_psd",
+    "sr_predict",
+    "sr_update",
+]

--- a/src/cw2017/models/conditionals.py
+++ b/src/cw2017/models/conditionals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple
 
+import jax
 import jax.numpy as jnp
 
 from ..kalman import smoother, sr_kf
@@ -12,6 +13,67 @@ from ..equity import constraints as equity_constraints
 from ..utils.logging import WorkUnitLogger
 
 work_logger = WorkUnitLogger()
+
+
+def _tile_theta(theta: jnp.ndarray, dim: int) -> jnp.ndarray:
+    reps = (dim + theta.size - 1) // theta.size
+    tiled = jnp.tile(theta, reps)
+    return tiled[:dim]
+
+
+def logpost_block3a_theta(
+    theta_block: jnp.ndarray,
+    fixed: Dict[str, Any],
+    data: Dict[str, Any],
+) -> jnp.float64:
+    """Minimal working log-posterior for block 3a parameters."""
+
+    theta_block = jnp.asarray(theta_block, dtype=jnp.float64)
+    h_t = fixed["h_t"]
+    y_t = data["y_t"]
+    m_t = data["m_t"]
+
+    params_template = data["params"]
+    params = dict(params_template)
+    params["theta"] = theta_block
+
+    def build_HR(t, params_obj, _h, _m):
+        theta = jnp.asarray(params_obj["theta"], dtype=jnp.float64)
+        obs_dim = y_t.shape[1]
+        state_dim = params_obj["a0"].shape[0]
+        scales = 0.5 + 0.5 * jnp.tanh(_tile_theta(theta, obs_dim))
+        eye = jnp.eye(state_dim, dtype=jnp.float64)
+        H = eye[:obs_dim, :] * scales[:, None]
+        R_diag = 0.1 + 0.05 * scales
+        R_chol = jnp.diag(R_diag)
+        return H, R_chol
+
+    def build_FQ(t, params_obj, _h, _m):
+        theta = jnp.asarray(params_obj["theta"], dtype=jnp.float64)
+        state_dim = params_obj["a0"].shape[0]
+        scales = 0.8 + 0.2 * jnp.tanh(_tile_theta(theta[::-1], state_dim))
+        F = jnp.eye(state_dim, dtype=jnp.float64) * scales
+        Q_diag = 0.05 + 0.02 * scales
+        Q_chol = jnp.diag(Q_diag)
+        return F, Q_chol
+
+    params["fns"] = {"build_HR": build_HR, "build_FQ": build_FQ}
+
+    log_prior = -0.5 * jnp.sum((theta_block / 3.0) ** 2)
+    log_prior -= theta_block.size * 0.5 * jnp.log(2.0 * jnp.pi * 9.0)
+
+    loglik, _ = sr_kf.sr_kf_loglik(params=params, h_t=h_t, y_t=y_t, m_t=m_t)
+    return log_prior + loglik
+
+
+def make_logpost_block3a_batched(
+    fixed: Dict[str, Any],
+    data: Dict[str, Any],
+) -> Any:
+    """Return a chain-batched logdensity for block 3a."""
+
+    single = lambda theta: logpost_block3a_theta(theta, fixed, data)
+    return jax.vmap(single)
 
 
 def logpost_block1_params(theta_block: Any, fixed: Dict[str, Any], data: Dict[str, Any]) -> jnp.float64:
@@ -66,6 +128,8 @@ def conjugate_cov_updates(theta_block: Any, fixed: Dict[str, Any], data: Dict[st
 
 __all__ = [
     "work_logger",
+    "logpost_block3a_theta",
+    "make_logpost_block3a_batched",
     "logpost_block1_params",
     "logpost_block2_q_eigs",
     "draw_block2b_g_and_means",

--- a/src/cw2017/samplers/gibbs.py
+++ b/src/cw2017/samplers/gibbs.py
@@ -1,22 +1,115 @@
-"""Main Gibbs sampler driver (placeholder implementation)."""
+"""Minimal Gibbs driver with a smoke-test 3a block update."""
 
 from __future__ import annotations
 
+import time
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
 
 from ..config import AppConfig
+from ..models.conditionals import logpost_block3a_theta
 from ..reporting import save_results, summarize
+from ..samplers.hmc_block import adapt_block_chees, hmc_block_step
 from ..utils.logging import setup_logging
 
 BLOCK_SEQUENCE = ["3a", "3b", "3c", "3d", "3e", "4", "5", "6"]
 
 
+@dataclass
+class SmokeState:
+    """State container for the smoke-test Gibbs sweep."""
+
+    theta_block3a: jnp.ndarray
+    hmc_state_3a: Optional[Any] = None
+    tuned_params_3a: Optional[Dict[str, Any]] = None
+    diagnostics_3a: Optional[Dict[str, Any]] = None
+    sweep: int = 0
+
+
+def run_one_sweep_smoke(
+    rng_key: jax.Array,
+    state: SmokeState,
+    cfg: Dict[str, Any],
+    data: Dict[str, Any],
+) -> Tuple[jax.Array, SmokeState, Dict[str, float]]:
+    """Execute a single Block 3a HMC update and record diagnostics."""
+
+    fixed = data["fixed"]
+    single_logdensity = lambda theta: logpost_block3a_theta(theta, fixed, data)
+
+    metrics: Dict[str, float] = {"block": "3a"}
+    start_time = time.time()
+
+    if state.tuned_params_3a is None or state.hmc_state_3a is None:
+        warmup_key, rng_key = jax.random.split(rng_key)
+        last_states, tuned_params, diag = adapt_block_chees(
+            warmup_key,
+            state.theta_block3a,
+            single_logdensity,
+            cfg.get("warmup", {}),
+        )
+        state = replace(
+            state,
+            hmc_state_3a=last_states,
+            tuned_params_3a=tuned_params,
+            diagnostics_3a=diag,
+            theta_block3a=last_states.position,
+        )
+        metrics["warmup_acceptance_hmean"] = float(diag["acceptance_hmean"])
+        metrics["warmup_ebfmi"] = float(diag["ebfmi"])
+        metrics["step_size"] = float(diag["final_step_size"])
+        metrics["trajectory_length"] = float(diag["final_trajectory_length"])
+
+    assert state.tuned_params_3a is not None and state.hmc_state_3a is not None
+
+    sample_key, rng_key = jax.random.split(rng_key)
+    new_state, info = hmc_block_step(sample_key, state.hmc_state_3a, state.tuned_params_3a)
+    theta_samples = new_state.position
+    state = replace(
+        state,
+        theta_block3a=theta_samples,
+        hmc_state_3a=new_state,
+        sweep=state.sweep + 1,
+    )
+
+    accept = jnp.asarray(info["acceptance"], dtype=jnp.float64)
+    metrics["acceptance"] = float(jnp.mean(accept))
+    metrics["duration_sec"] = float(time.time() - start_time)
+    metrics["step_size"] = float(state.tuned_params_3a["step_size"])
+    metrics.setdefault("warmup_ebfmi", float("nan"))
+    metrics.setdefault("warmup_acceptance_hmean", float("nan"))
+    metrics["trajectory_length"] = float(
+        state.diagnostics_3a.get("final_trajectory_length")
+        if state.diagnostics_3a
+        else float("nan")
+    )
+
+    return rng_key, state, metrics
+
+
+def run_smoke_sweeps(
+    rng_key: jax.Array,
+    state: SmokeState,
+    cfg: Dict[str, Any],
+    data: Dict[str, Any],
+    num_sweeps: int,
+) -> Tuple[jax.Array, SmokeState, List[Dict[str, float]]]:
+    """Run ``num_sweeps`` of the smoke Gibbs sampler."""
+
+    metrics: List[Dict[str, float]] = []
+    for _ in range(num_sweeps):
+        rng_key, state, record = run_one_sweep_smoke(rng_key, state, cfg, data)
+        record["sweep"] = state.sweep
+        metrics.append(record)
+    return rng_key, state, metrics
+
+
 def run_gibbs(rng_key: jax.Array, config: AppConfig, results_root: Path) -> Dict[str, object]:
-    """Execute a single Gibbs sweep and write a dummy report."""
+    """Execute a placeholder Gibbs sweep (legacy entry point)."""
 
     setup_logging(level=config.logging.level, rich_tracebacks=config.logging.rich_tracebacks)
     run_id = save_results.build_run_id(config.run.run_id_prefix)
@@ -28,13 +121,11 @@ def run_gibbs(rng_key: jax.Array, config: AppConfig, results_root: Path) -> Dict
             {
                 "block": block,
                 "acceptance": 1.0,
-                "ess_per_second": 0.0,
-                "work_units": 0.0,
+                "duration_sec": 0.0,
             }
         )
 
-    summary_df = summarize.summarise_blocks(block_metrics)
-    summarize.write_summary(summary_df, summary_dir)
+    summarize.write_summary(summary_dir, block_metrics)
     save_results.write_metadata(
         summary_dir,
         {
@@ -43,7 +134,13 @@ def run_gibbs(rng_key: jax.Array, config: AppConfig, results_root: Path) -> Dict
             "seed": config.run.seed,
         },
     )
-    return {"run_id": run_id, "summary": summary_df}
+    return {"run_id": run_id, "summary": block_metrics}
 
 
-__all__ = ["run_gibbs", "BLOCK_SEQUENCE"]
+__all__ = [
+    "run_gibbs",
+    "BLOCK_SEQUENCE",
+    "SmokeState",
+    "run_one_sweep_smoke",
+    "run_smoke_sweeps",
+]

--- a/src/cw2017/samplers/hmc_block.py
+++ b/src/cw2017/samplers/hmc_block.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Mapping, Tuple
 
+import jax
 import jax.numpy as jnp
 import optax
 
@@ -12,7 +13,7 @@ from ..typing import Array, PRNGKey
 
 
 def _import_blackjax():
-    try:
+    try:  # pragma: no cover - import failure should be explicit
         import blackjax  # type: ignore
     except ImportError as exc:  # pragma: no cover - dependency should be present
         raise RuntimeError("blackjax must be installed to use HMC kernels") from exc
@@ -27,12 +28,26 @@ class BlockKernel:
     parameters: Dict[str, Any]
 
 
-def _get_cfg_value(cfg: Any, name: str, default: Any) -> Any:
-    if hasattr(cfg, name):
-        return getattr(cfg, name)
-    if isinstance(cfg, dict):
+def _cfg_value(cfg: Any, name: str, default: Any) -> Any:
+    if isinstance(cfg, Mapping):
         return cfg.get(name, default)
-    return default
+    return getattr(cfg, name, default)
+
+
+def _harmonic_mean(values: Array) -> jnp.float64:
+    eps = 1e-9
+    clipped = jnp.clip(values, min=eps)
+    return jnp.array(values.size, dtype=jnp.float64) / jnp.sum(1.0 / clipped)
+
+
+def _compute_ebfmi(energies: Array) -> jnp.float64:
+    if energies.shape[0] <= 1:
+        return jnp.nan
+    diffs = jnp.diff(energies, axis=0)
+    numerator = jnp.var(energies, axis=0)
+    denominator = jnp.mean(diffs**2, axis=0) + 1e-12
+    ebfmi = numerator / denominator
+    return jnp.mean(ebfmi)
 
 
 def adapt_block_chees(
@@ -40,37 +55,74 @@ def adapt_block_chees(
     init_positions: Array,
     logdensity_fn: Callable[[Array], jnp.float64],
     warmup_cfg: Any,
-) -> Tuple[Array, BlockKernel, Dict[str, Any]]:
-    """Run ChEES adaptation to tune an HMC kernel."""
+) -> Tuple[Any, Dict[str, Any], Dict[str, Any]]:
+    """Run ChEES adaptation to tune a dynamic HMC kernel."""
 
-    blackjax = _import_blackjax()
+    _ = _import_blackjax()
+    from blackjax.adaptation.chees_adaptation import chees_adaptation
+
     num_chains = init_positions.shape[0]
-    num_steps = int(_get_cfg_value(warmup_cfg, "num_steps", 10))
-    target_acceptance = float(_get_cfg_value(warmup_cfg, "target_acceptance", 0.651))
-    chees = blackjax.adaptation.chees_adaptation(
+    warmup_steps = int(_cfg_value(warmup_cfg, "num_warmup_steps", 50))
+    target_accept = float(_cfg_value(warmup_cfg, "target_accept", 0.651))
+    jitter_amount = float(_cfg_value(warmup_cfg, "jitter_amount", 1.0))
+    decay_rate = float(_cfg_value(warmup_cfg, "decay_rate", 0.5))
+    lr = float(_cfg_value(warmup_cfg, "adam_lr", 0.02))
+    init_step_size = float(_cfg_value(warmup_cfg, "initial_step_size", 0.1))
+
+    init_positions = jnp.asarray(init_positions, dtype=jnp.float64)
+    adaptation = chees_adaptation(
         logdensity_fn,
         num_chains=num_chains,
-        target_acceptance_rate=target_acceptance,
-        jitter_amount=1.0,
-        decay_rate=0.5,
-        optimizer=optax.adam(0.02),
+        target_acceptance_rate=target_accept,
+        jitter_amount=jitter_amount,
+        decay_rate=decay_rate,
     )
-    adaptation_state, last_states, parameters = chees.run(rng_key, init_positions, num_steps)
-    tuned_kernel = BlockKernel(logdensity_fn=logdensity_fn, parameters=parameters)
+    optim = optax.adam(lr)
+    results, info = adaptation.run(rng_key, init_positions, init_step_size, optim, warmup_steps)
+
+    tuned_params = dict(results.parameters)
+    tuned_params["logdensity_fn"] = logdensity_fn
+
+    acceptance = info.info.acceptance_rate.astype(jnp.float64)
+    energies = info.info.energy.astype(jnp.float64)
+    harmonic_accept = _harmonic_mean(acceptance.reshape(-1))
+    ebfmi = _compute_ebfmi(energies)
+    traj = info.adaptation_state.trajectory_length.astype(jnp.float64)
+    final_traj = traj[-1] if traj.shape[0] else jnp.nan
+
     diagnostics = {
-        "acceptance_rate": getattr(adaptation_state, "acceptance_rate", None),
-        "step_size": parameters.get("step_size"),
+        "acceptance_trace": acceptance,
+        "acceptance_hmean": harmonic_accept,
+        "ebfmi": ebfmi,
+        "final_step_size": jnp.asarray(tuned_params["step_size"], dtype=jnp.float64),
+        "final_trajectory_length": final_traj,
     }
-    return last_states, tuned_kernel, diagnostics
+    return results.state, tuned_params, diagnostics
 
 
-def hmc_block_step(rng_key: PRNGKey, state: Any, tuned_kernel: BlockKernel) -> Tuple[Any, Dict[str, Any]]:
-    """Advance one dynamic HMC step using the tuned kernel."""
+def hmc_block_step(
+    rng_key: PRNGKey,
+    state: Any,
+    tuned_params: Mapping[str, Any],
+) -> Tuple[Any, Dict[str, Array]]:
+    """Advance one dynamic HMC step using tuned parameters."""
 
     blackjax = _import_blackjax()
-    kernel = blackjax.dynamic_hmc(tuned_kernel.logdensity_fn, **tuned_kernel.parameters)
-    new_state, info = kernel.step(rng_key, state)
-    return new_state, {"acceptance": getattr(info, "acceptance_rate", None)}
+    logdensity_fn = tuned_params["logdensity_fn"]
+    kernel_params = {k: v for k, v in tuned_params.items() if k != "logdensity_fn"}
+    kernel = blackjax.dynamic_hmc(logdensity_fn, **kernel_params)
+
+    num_chains = state.position.shape[0]
+    keys = jax.random.split(rng_key, num_chains)
+    step = jax.vmap(kernel.step, in_axes=(0, 0))
+    new_state, info = step(keys, state)
+    diagnostics = {
+        "acceptance": info.acceptance_rate,
+        "energy": info.energy,
+        "is_divergent": info.is_divergent,
+        "num_integration_steps": info.num_integration_steps,
+    }
+    return new_state, diagnostics
 
 
 __all__ = ["BlockKernel", "adapt_block_chees", "hmc_block_step"]

--- a/tests/test_kalman_stub.py
+++ b/tests/test_kalman_stub.py
@@ -1,19 +1,50 @@
-"""Ensure the SR-KF stub executes without numerical issues."""
+"""SR-Kalman filter smoke tests."""
 
 from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
 
-from cw2017.utils import jax_setup  # noqa: F401
 from cw2017.kalman import sr_kf
+from cw2017.utils import jax_setup  # noqa: F401
 
 
-def test_sr_kf_random_system() -> None:
-    key = jax.random.PRNGKey(42)
-    y_t = jax.random.normal(key, (4, 3), dtype=jnp.float64)
-    h_t = jnp.zeros_like(y_t)
-    m_t = jnp.zeros_like(y_t)
-    loglik, aux = sr_kf.sr_kf_loglik({}, h_t, y_t, m_t)
+def _identity_builders(state_dim: int, obs_dim: int):
+    def build_HR(t, params, h_t, m_t):
+        H = jnp.eye(state_dim, dtype=jnp.float64)[:obs_dim, :]
+        R = 0.1 * jnp.eye(obs_dim, dtype=jnp.float64)
+        return H, R
+
+    def build_FQ(t, params, h_t, m_t):
+        F = jnp.eye(state_dim, dtype=jnp.float64)
+        Q = 0.05 * jnp.eye(state_dim, dtype=jnp.float64)
+        return F, Q
+
+    return build_HR, build_FQ
+
+
+def test_sr_kf_loglik_shapes() -> None:
+    key = jax.random.PRNGKey(0)
+    T, state_dim, obs_dim = 8, 4, 3
+    y_key, h_key, m_key = jax.random.split(key, 3)
+    y_t = jax.random.normal(y_key, (T, obs_dim), dtype=jnp.float64)
+    h_t = jax.random.normal(h_key, (T, state_dim), dtype=jnp.float64)
+    m_t = jax.random.normal(m_key, (T, 2), dtype=jnp.float64)
+
+    build_HR, build_FQ = _identity_builders(state_dim, obs_dim)
+    params = {
+        "a0": jnp.zeros(state_dim, dtype=jnp.float64),
+        "S0": jnp.eye(state_dim, dtype=jnp.float64) * 0.4,
+        "fns": {"build_HR": build_HR, "build_FQ": build_FQ},
+    }
+
+    loglik, aux = sr_kf.sr_kf_loglik(params, h_t, y_t, m_t)
     assert jnp.isfinite(loglik)
-    assert jnp.all(jnp.isfinite(aux["innovations"]))
+    assert aux["filtered_means"].shape == (T, state_dim)
+    assert aux["filtered_sqrt_covs"].shape == (T, state_dim, state_dim)
+    assert not bool(aux["nan_detected"])
+
+    compiled = jax.jit(lambda h, y, m: sr_kf.sr_kf_loglik(params, h, y, m))
+    loglik_jit, aux_jit = compiled(h_t, y_t, m_t)
+    assert jnp.isfinite(loglik_jit)
+    assert aux_jit["filtered_means"].shape == (T, state_dim)

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,4 +1,4 @@
-"""Shape and dtype smoke tests for key stubs."""
+"""Shape and dtype smoke tests for selected utilities."""
 
 from __future__ import annotations
 
@@ -7,24 +7,18 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from cw2017.utils import jax_setup  # noqa: F401
-from cw2017.kalman import sr_kf, smoother
 from cw2017.equity import constraints
-
-
-def test_sr_kf_shapes() -> None:
-    params = {}
-    h_t = jnp.zeros((5, 2))
-    y_t = jnp.zeros((5, 2))
-    m_t = jnp.zeros((5, 2))
-    loglik, aux = sr_kf.sr_kf_loglik(params, h_t, y_t, m_t)
-    assert loglik.shape == ()
-    assert aux["innovations"].shape == (5, 2)
+from cw2017.samplers.hmc_block import adapt_block_chees, hmc_block_step
+from cw2017.utils import jax_setup  # noqa: F401
 
 
 def test_smoother_output_shapes() -> None:
     key = jax.random.PRNGKey(0)
-    g_sample, means = smoother.dk_simulation_smoother({}, jnp.zeros((5, 2)), jnp.zeros((5, 2)), jnp.zeros((5, 2)), key)
+    from cw2017.kalman import smoother  # imported lazily to avoid circular deps
+
+    g_sample, means = smoother.dk_simulation_smoother(
+        {}, jnp.zeros((5, 2)), jnp.zeros((5, 2)), jnp.zeros((5, 2)), key
+    )
     assert g_sample.shape == (5, 2)
     assert means.shape == (5, 2)
 
@@ -33,3 +27,27 @@ def test_equity_constraint_identity() -> None:
     means = jnp.ones((3,))
     constrained = constraints.solve_linear_equity_constraint({}, means)
     np.testing.assert_allclose(constrained, means)
+
+
+def test_hmc_block_adaptation_smoke() -> None:
+    key = jax.random.PRNGKey(123)
+
+    def logdensity(theta: jnp.ndarray) -> jnp.float64:
+        return -0.5 * jnp.sum(theta**2)
+
+    init_positions = jnp.zeros((3, 4), dtype=jnp.float64)
+    warmup_cfg = {
+        "num_warmup_steps": 6,
+        "initial_step_size": 0.2,
+        "target_accept": 0.65,
+        "jitter_amount": 0.8,
+    }
+    last_states, tuned_params, diagnostics = adapt_block_chees(key, init_positions, logdensity, warmup_cfg)
+    assert last_states.position.shape == init_positions.shape
+    assert float(tuned_params["step_size"]) > 0.0
+    assert float(diagnostics["final_trajectory_length"]) > 0.0
+
+    sample_key = jax.random.PRNGKey(456)
+    new_state, info = hmc_block_step(sample_key, last_states, tuned_params)
+    assert new_state.position.shape == init_positions.shape
+    assert info["acceptance"].shape == (init_positions.shape[0],)


### PR DESCRIPTION
## Summary
- implement a numerically stable square-root Kalman filter with QR-based predict/update steps and diagnostics
- add per-block HMC adaptation/step helpers, block 3a log posterior, smoke Gibbs sweep plumbing, and CLI flag to run a short synthetic sweep
- write CSV/text summaries and strengthen tests for the Kalman filter and HMC warm-up

## Testing
- python -m scripts.run_gibbs --smoke --chains 4 --seed 0
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06018433c8320944f1fcf47feacf4