### PR TITLE
Add utility to auto-install missing packages

### DIFF
--- a/src/cw2017/samplers/hmc_block.py
+++ b/src/cw2017/samplers/hmc_block.py
@@ -10,13 +10,15 @@ import jax.numpy as jnp
 import optax
 
 from ..typing import Array, PRNGKey
+from ..utils import ensure_packages_installed
 
 
 def _import_blackjax():
     try:  # pragma: no cover - import failure should be explicit
         import blackjax  # type: ignore
-    except ImportError as exc:  # pragma: no cover - dependency should be present
-        raise RuntimeError("blackjax must be installed to use HMC kernels") from exc
+    except ImportError:
+        ensure_packages_installed({"blackjax": "blackjax"})
+        import blackjax  # type: ignore
     return blackjax
 
 

--- a/src/cw2017/utils/__init__.py
+++ b/src/cw2017/utils/__init__.py
@@ -1,1 +1,5 @@
-"""utils package."""
+"""Utility helpers for the :mod:`cw2017` package."""
+
+from .packages import PackageInstallationError, ensure_packages_installed
+
+__all__ = ["PackageInstallationError", "ensure_packages_installed"]

--- a/src/cw2017/utils/packages.py
+++ b/src/cw2017/utils/packages.py
@@ -1,0 +1,77 @@
+"""Helpers for ensuring optional runtime dependencies are available."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping
+from typing import Dict
+
+
+class PackageInstallationError(RuntimeError):
+    """Raised when an automatic dependency installation fails."""
+
+
+PackageSpec = Dict[str, str]
+
+
+def _normalise_packages(packages: Iterable[str] | Mapping[str, str] | str) -> PackageSpec:
+    """Return a mapping of import names to pip install specifications."""
+
+    if isinstance(packages, str):
+        return {packages: packages}
+
+    if isinstance(packages, Mapping):
+        return dict(packages)
+
+    normalised: Dict[str, str] = {}
+    for name in packages:
+        normalised[name] = name
+    return normalised
+
+
+def _module_available(module_name: str) -> bool:
+    """Return ``True`` if ``module_name`` can be imported."""
+
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _install_package(spec: str) -> None:
+    """Install ``spec`` using ``pip``."""
+
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", spec])
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive
+        raise PackageInstallationError(f"Failed to install required package '{spec}'.") from exc
+
+
+def ensure_packages_installed(packages: Iterable[str] | Mapping[str, str] | str) -> None:
+    """Ensure that each requested package can be imported.
+
+    Parameters
+    ----------
+    packages:
+        Either a string naming a package, an iterable of strings, or a mapping from
+        module import names to pip install specifications. When a package is
+        missing it will be installed using ``pip``.
+    """
+
+    package_specs = _normalise_packages(packages)
+    missing = [(name, spec) for name, spec in package_specs.items() if not _module_available(name)]
+
+    for import_name, install_spec in missing:
+        _install_package(install_spec)
+        importlib.invalidate_caches()
+        if not _module_available(import_name):
+            raise PackageInstallationError(
+                f"Package '{install_spec}' was installed but '{import_name}' could still not be imported."
+            )
+
+
+__all__ = ["ensure_packages_installed", "PackageInstallationError"]
+

--- a/tests/test_utils_packages.py
+++ b/tests/test_utils_packages.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+from cw2017.utils.packages import (
+    PackageInstallationError,
+    ensure_packages_installed,
+)
+
+
+def test_ensure_packages_installed_noop_when_present(monkeypatch):
+    def fake_find_spec(name: str):
+        return object()
+
+    def fail_check_call(*args, **kwargs):  # pragma: no cover - defensive
+        raise AssertionError("pip should not be invoked when package is available")
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(subprocess, "check_call", fail_check_call)
+
+    ensure_packages_installed("already_there")
+
+
+def test_ensure_packages_installed_installs_missing(monkeypatch):
+    installed = {"needs_install": False}
+
+    def fake_find_spec(name: str):
+        if installed["needs_install"]:
+            return object()
+        return None
+
+    def fake_check_call(cmd, **kwargs):
+        assert cmd[:4] == [sys.executable, "-m", "pip", "install"]
+        assert cmd[4] == "needs_install"
+        installed["needs_install"] = True
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(subprocess, "check_call", fake_check_call)
+
+    ensure_packages_installed("needs_install")
+    assert installed["needs_install"]
+
+
+def test_ensure_packages_installed_raises_on_failure(monkeypatch):
+    def fake_find_spec(name: str):
+        return None
+
+    def fake_check_call(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(subprocess, "check_call", fake_check_call)
+
+    with pytest.raises(PackageInstallationError):
+        ensure_packages_installed("never_installs")


### PR DESCRIPTION
## Summary
- add an ``ensure_packages_installed`` helper that installs missing runtime dependencies
- export the helper from the utils package and use it when importing ``blackjax``
- cover the installer behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d071218c3c8320a23ca3955b7780e1