### PR TITLE
Add JAX linear algebra utilities and tests

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,12 @@
+"""Utility functions for linear algebra and array selectors."""
+
+from .linalg import chol_solve_spd, safe_cholesky, symmetrize, tri_solve
+from . import selectors
+
+__all__ = [
+    "safe_cholesky",
+    "chol_solve_spd",
+    "tri_solve",
+    "symmetrize",
+    "selectors",
+]

--- a/src/utils/linalg.py
+++ b/src/utils/linalg.py
@@ -1,0 +1,80 @@
+"""Linear algebra utilities built on top of JAX."""
+
+from __future__ import annotations
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax.scipy.linalg import solve_triangular
+
+Array = jax.Array
+
+
+def symmetrize(S: Array | jnp.ndarray) -> Array:
+    """Return the symmetric part of ``S`` as a float64 array."""
+    S64 = jnp.asarray(S, dtype=jnp.float64)
+    return 0.5 * (S64 + S64.T)
+
+
+def safe_cholesky(S: Array | jnp.ndarray, jitter: float = 1e-10, max_tries: int = 5) -> Array:
+    """Return a lower-triangular ``L`` with ``S ≈ L Lᵀ``.
+
+    Parameters
+    ----------
+    S:
+        Symmetric positive definite matrix to factorise. The input is symmetrised
+        to avoid numerical asymmetry issues and is always treated as ``float64``.
+    jitter:
+        Initial diagonal regularisation added when attempting the factorisation.
+    max_tries:
+        Maximum number of attempts made with exponentially increasing jitter.
+
+    Returns
+    -------
+    jax.Array
+        Lower-triangular Cholesky factor of ``S``.
+
+    Raises
+    ------
+    np.linalg.LinAlgError
+        If the matrix cannot be factorised after ``max_tries`` attempts.
+    """
+
+    if max_tries < 1:
+        raise ValueError("max_tries must be at least 1")
+
+    S_sym = symmetrize(S)
+    if S_sym.ndim != 2 or S_sym.shape[0] != S_sym.shape[1]:
+        raise ValueError("S must be a square matrix")
+    n = S_sym.shape[0]
+
+    eye = jnp.eye(n, dtype=jnp.float64)
+    eps = 0.0
+    for _ in range(max_tries):
+        try:
+            return jnp.linalg.cholesky(S_sym + (eps + jitter) * eye)
+        except Exception:  # pragma: no cover - JAX raises custom errors
+            eps = 10.0 * (eps + jitter)
+    raise np.linalg.LinAlgError("Cholesky failed")
+
+
+def chol_solve_spd(L: Array | jnp.ndarray, B: Array | jnp.ndarray) -> Array:
+    """Solve ``(L Lᵀ) X = B`` for ``X`` using the provided Cholesky factor ``L``."""
+    L64 = jnp.asarray(L, dtype=jnp.float64)
+    B64 = jnp.asarray(B, dtype=jnp.float64)
+    y = solve_triangular(L64, B64, lower=True, trans="N")
+    x = solve_triangular(L64, y, lower=True, trans="T")
+    return x
+
+
+def tri_solve(
+    L: Array | jnp.ndarray,
+    B: Array | jnp.ndarray,
+    *,
+    lower: bool = True,
+    trans: str | int = "N",
+) -> Array:
+    """Solve a triangular system using float64 precision."""
+    L64 = jnp.asarray(L, dtype=jnp.float64)
+    B64 = jnp.asarray(B, dtype=jnp.float64)
+    return solve_triangular(L64, B64, lower=lower, trans=trans)

--- a/src/utils/selectors.py
+++ b/src/utils/selectors.py
@@ -1,0 +1,46 @@
+"""Selectors and structured matrix constructors."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+
+def e_last(d: int) -> jnp.ndarray:
+    """Row selector for the last element of a length-``d`` vector."""
+    if d < 1:
+        raise ValueError("d must be positive")
+    return jnp.eye(d, dtype=jnp.float64)[-1, :]
+
+
+def e1(d: int) -> jnp.ndarray:
+    """Row selector for the first element of a length-``d`` vector."""
+    if d < 1:
+        raise ValueError("d must be positive")
+    return jnp.eye(d, dtype=jnp.float64)[0, :]
+
+
+def block_diag(*blocks: jnp.ndarray) -> jnp.ndarray:
+    """Block-diagonal concatenation of matrices using zeros for off-diagonals."""
+    if not blocks:
+        raise ValueError("block_diag requires at least one block")
+
+    arrays = [jnp.asarray(block) for block in blocks]
+    if any(arr.ndim != 2 for arr in arrays):
+        raise ValueError("All blocks must be two-dimensional")
+
+    dtype = jnp.result_type(*arrays)
+    total_rows = sum(arr.shape[0] for arr in arrays)
+    total_cols = sum(arr.shape[1] for arr in arrays)
+    out = jnp.zeros((total_rows, total_cols), dtype=dtype)
+
+    row_offset = 0
+    col_offset = 0
+    for arr in arrays:
+        h, w = arr.shape
+        out = out.at[row_offset : row_offset + h, col_offset : col_offset + w].set(
+            jnp.asarray(arr, dtype=dtype)
+        )
+        row_offset += h
+        col_offset += w
+
+    return out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+import numpy as np
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import jax.numpy as jnp
+
+from utils.linalg import chol_solve_spd, safe_cholesky
+from utils.selectors import block_diag
+
+
+def test_safe_cholesky_matches_numpy():
+    rng = np.random.default_rng(123)
+    A = rng.standard_normal((4, 4))
+    S = A @ A.T + 0.5 * np.eye(4)
+    B = rng.standard_normal((4, 3))
+
+    S_jax = jnp.asarray(S, dtype=jnp.float64)
+    B_jax = jnp.asarray(B, dtype=jnp.float64)
+
+    L = safe_cholesky(S_jax)
+    assert L.shape == (4, 4)
+    assert jnp.allclose(L, jnp.tril(L))
+
+    L_np = np.linalg.cholesky(S)
+    np.testing.assert_allclose(np.array(L), L_np, atol=1e-8)
+
+    x_jax = chol_solve_spd(L, B_jax)
+    x_np = np.linalg.solve(S, B)
+    np.testing.assert_allclose(np.array(x_jax), x_np, atol=1e-8)
+
+
+def test_block_diag_three_blocks():
+    b1 = jnp.array([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.float64)
+    b2 = jnp.array([[5.0, 6.0, 7.0]], dtype=jnp.float64)
+    b3 = jnp.array([[8.0], [9.0], [10.0]], dtype=jnp.float64)
+
+    result = block_diag(b1, b2, b3)
+
+    expected = jnp.zeros((6, 6), dtype=jnp.float64)
+    expected = expected.at[0:2, 0:2].set(b1)
+    expected = expected.at[2:3, 2:5].set(b2)
+    expected = expected.at[3:6, 5:6].set(b3)
+
+    assert result.shape == (6, 6)
+    np.testing.assert_allclose(np.array(result), np.array(expected))


### PR DESCRIPTION
## Summary
- add a new `utils` package with JAX-based linear algebra helpers
- implement selector utilities including `block_diag`
- add unit tests that validate `safe_cholesky` and `block_diag`

## Testing
- pytest tests/test_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d159f5ee70832091ac9419b0b071de