### PR TITLE
Add equity constraint coefficients and tests

### DIFF
--- a/src/equity_constraint.py
+++ b/src/equity_constraint.py
@@ -1,0 +1,124 @@
+"""Equity constraint coefficients derived from Creal & Wu (2017)."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.scipy.linalg
+
+from utils.selectors import e_last, e1
+
+
+def compute_M0Q_from_B_and_Sigma_gQ(
+    B_rows: jnp.ndarray,
+    Sigma_gQ: jnp.ndarray,
+    *,
+    n_star: int = 60,
+) -> jnp.ndarray:
+    r"""Return :math:`M_0^Q` using Appendix A.2 of Creal & Wu (2017).
+
+    Parameters
+    ----------
+    B_rows:
+        Matrix whose ``i``-th row stores :math:`b_{i,g}` for horizon ``i``. The
+        matrix must include at least ``n_star - 1`` rows.
+    Sigma_gQ:
+        Rotation matrix :math:`\Sigma_g^Q` (Appendix A.2).
+    n_star:
+        Horizon count :math:`n^*` used for the annuity averaging.
+
+    Returns
+    -------
+    jax.Array
+        Vector ``(3,)`` holding ``M_0^Q`` as defined in Appendix A.2.
+    """
+
+    if n_star < 2:
+        raise ValueError("n_star must be at least 2")
+
+    B64 = jnp.asarray(B_rows, dtype=jnp.float64)
+    Sigma64 = jnp.asarray(Sigma_gQ, dtype=jnp.float64)
+
+    if B64.shape[0] < n_star - 1:
+        raise ValueError("B_rows must have at least n_star - 1 rows")
+    if B64.ndim != 2:
+        raise ValueError("B_rows must be a matrix")
+    if Sigma64.ndim != 2 or Sigma64.shape[0] != Sigma64.shape[1]:
+        raise ValueError("Sigma_gQ must be square")
+    if B64.shape[1] != Sigma64.shape[0]:
+        raise ValueError("Column dimension mismatch between B_rows and Sigma_gQ")
+
+    GG = Sigma64 @ Sigma64.T
+    inner = jnp.float64(0.0)
+    for i in range(1, n_star):
+        b = B64[i - 1, :]
+        inner = inner + (i**2) * (b @ GG @ b)
+    top = -0.5 * inner / n_star
+    return jnp.array([top, 0.0, 0.0], dtype=jnp.float64)
+
+
+def equity_coeffs(fixed: dict[str, jnp.ndarray], cfg: dict) -> tuple[jnp.ndarray, jnp.ndarray]:
+    r"""Compute ``(a, b)`` for ``a^T \mu + b < 0`` (Appendix B.1.1, A.2).
+
+    The coefficient vectors follow the Form I restriction from Creal & Wu (2017,
+    Appendix B.1.1) while mapping Q-measure quantities using the rotations in
+    Appendix A.2.  The state mean is ordered as
+    ``mu = concat([mu_m_bar, mu_g_u_bar, mu_gQ_u_bar])`` with ``d_g = 3``.
+    """
+
+    d_m = int(cfg["dims"]["d_m"])
+
+    e_d = e_last(d_m)
+    e1g = e1(3)
+
+    Phi_m = jnp.asarray(fixed["Phi_m"], dtype=jnp.float64)
+    Phi_mg = jnp.asarray(fixed["Phi_mg"], dtype=jnp.float64)
+    Phi_mh = jnp.asarray(fixed["Phi_mh"], dtype=jnp.float64)
+    Phi_gQ = jnp.asarray(fixed["Phi_gQ"], dtype=jnp.float64)
+    Sigma_gQ = jnp.asarray(fixed["Sigma_gQ"], dtype=jnp.float64)
+    Sigma_h = jnp.asarray(fixed["Sigma_h"], dtype=jnp.float64)
+    Sigma_hm = jnp.asarray(fixed["Sigma_hm"], dtype=jnp.float64)
+    Sigma_hg = jnp.asarray(fixed["Sigma_hg"], dtype=jnp.float64)
+    mu_hbar = jnp.asarray(fixed["mu_h_bar"], dtype=jnp.float64)
+
+    bar = fixed["bar"]
+    bar_mm = jnp.asarray(bar["mm"], dtype=jnp.float64)
+    bar_mg = jnp.asarray(bar["mg"], dtype=jnp.float64)
+    bar_mh = jnp.asarray(bar["mh"], dtype=jnp.float64)
+    bar_hh = jnp.asarray(bar["hh"], dtype=jnp.float64)
+
+    M0Q = jnp.asarray(fixed["M0Q"], dtype=jnp.float64)
+    M1Q = jnp.asarray(fixed["M1Q"], dtype=jnp.float64)
+
+    Sg_free = jnp.asarray(fixed["Sg_free"], dtype=jnp.float64)
+
+    Im = jnp.eye(d_m, dtype=jnp.float64)
+    solve_Im_Phi_m = jax.scipy.linalg.solve(Im - Phi_m, Im, assume_a="gen")
+
+    theta_m = e_d @ solve_Im_Phi_m @ bar_mm
+    theta_g = e_d @ solve_Im_Phi_m @ bar_mg
+
+    row_q = (e_d @ solve_Im_Phi_m @ Phi_mg) - e1g
+    theta_gQ = row_q @ M1Q
+
+    term1 = (e_d @ solve_Im_Phi_m @ bar_mh + e_d @ Phi_mh @ bar_hh) @ mu_hbar
+    term2 = row_q @ M0Q
+
+    d_g = Phi_gQ.shape[0]
+    Ig = jnp.eye(d_g, dtype=jnp.float64)
+    S = jax.scipy.linalg.solve(Ig - Phi_gQ, Sigma_gQ, assume_a="gen")
+    vec = row_q @ S
+    add = (e_d @ Phi_mh) @ Sigma_hg
+
+    term3 = 0.5 * (vec @ (vec + add))
+    Sigma_block = Sigma_hm @ Sigma_hm.T + Sigma_h @ Sigma_h.T
+    term4 = 0.5 * (e_d @ Phi_mh) @ Sigma_block @ (Phi_mh.T @ e_d)
+    term5 = 0.5 * (add @ add)
+
+    V = term1 + term2 + term3 + term4 + term5
+
+    theta_g_free = Sg_free @ theta_g
+
+    a = jnp.concatenate([theta_m, theta_g_free, theta_gQ])
+    b = jnp.asarray(V, dtype=jnp.float64)
+    return a, b

--- a/tests/test_equity_constraint.py
+++ b/tests/test_equity_constraint.py
@@ -1,0 +1,100 @@
+"""Unit tests for equity constraint construction."""
+
+from __future__ import annotations
+
+import numpy as np
+import jax.numpy as jnp
+
+from equity_constraint import compute_M0Q_from_B_and_Sigma_gQ, equity_coeffs
+
+
+def test_compute_m0q_matches_scalar_bruteforce():
+    rng = np.random.default_rng(0)
+    n_star = 5
+    d_g = 3
+    B_rows = rng.standard_normal((n_star - 1, d_g))
+    Sigma_gQ = rng.standard_normal((d_g, d_g))
+
+    result = compute_M0Q_from_B_and_Sigma_gQ(B_rows, Sigma_gQ, n_star=n_star)
+
+    GG = Sigma_gQ @ Sigma_gQ.T
+    inner = 0.0
+    for i in range(1, n_star):
+        b = B_rows[i - 1]
+        inner += (i**2) * float(b @ GG @ b)
+    expected = np.array([-0.5 * inner / n_star, 0.0, 0.0], dtype=np.float64)
+
+    assert result.shape == (3,)
+    np.testing.assert_allclose(np.asarray(result), expected, rtol=1e-12, atol=1e-12)
+
+
+def test_equity_coeffs_returns_finite_a_and_b_and_inequality():
+    rng = np.random.default_rng(1)
+    d_m = 3
+    d_g = 3
+    d_h = 2
+
+    Phi_m = 0.1 * rng.standard_normal((d_m, d_m))
+    Phi_mg = 0.1 * rng.standard_normal((d_m, d_g))
+    Phi_mh = 0.1 * rng.standard_normal((d_m, d_h))
+    Phi_gQ = 0.05 * rng.standard_normal((d_g, d_g))
+
+    Sigma_gQ = rng.standard_normal((d_g, d_g))
+    Ah = rng.standard_normal((d_h, d_h))
+    Sigma_h = Ah @ Ah.T + np.eye(d_h)
+    Sigma_hm = rng.standard_normal((d_h, d_m))
+    Sigma_hg = rng.standard_normal((d_h, d_g))
+    mu_h_bar = rng.standard_normal(d_h)
+
+    bar_mm = np.eye(d_m)
+    bar_mg = rng.standard_normal((d_m, d_g))
+    bar_mh = rng.standard_normal((d_m, d_h))
+    bar_hh = np.eye(d_h)
+
+    n_star = 60
+    B_rows = rng.standard_normal((n_star - 1, d_g))
+    M0Q = compute_M0Q_from_B_and_Sigma_gQ(B_rows, Sigma_gQ, n_star=n_star)
+    M1Q = rng.standard_normal((d_g, 2))
+
+    Sg_free = jnp.array([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=jnp.float64)
+
+    fixed = {
+        "Phi_m": jnp.asarray(Phi_m, dtype=jnp.float64),
+        "Phi_mg": jnp.asarray(Phi_mg, dtype=jnp.float64),
+        "Phi_mh": jnp.asarray(Phi_mh, dtype=jnp.float64),
+        "Phi_gQ": jnp.asarray(Phi_gQ, dtype=jnp.float64),
+        "Sigma_gQ": jnp.asarray(Sigma_gQ, dtype=jnp.float64),
+        "Sigma_h": jnp.asarray(Sigma_h, dtype=jnp.float64),
+        "Sigma_hm": jnp.asarray(Sigma_hm, dtype=jnp.float64),
+        "Sigma_hg": jnp.asarray(Sigma_hg, dtype=jnp.float64),
+        "mu_h_bar": jnp.asarray(mu_h_bar, dtype=jnp.float64),
+        "bar": {
+            "mm": jnp.asarray(bar_mm, dtype=jnp.float64),
+            "mg": jnp.asarray(bar_mg, dtype=jnp.float64),
+            "mh": jnp.asarray(bar_mh, dtype=jnp.float64),
+            "hh": jnp.asarray(bar_hh, dtype=jnp.float64),
+        },
+        "M0Q": M0Q,
+        "M1Q": jnp.asarray(M1Q, dtype=jnp.float64),
+        "Sg_free": Sg_free,
+    }
+
+    cfg = {"dims": {"d_m": d_m}}
+
+    a, b = equity_coeffs(fixed, cfg)
+
+    expected_length = d_m + Sg_free.shape[0] + M1Q.shape[1]
+    assert a.shape == (expected_length,)
+    assert b.shape == ()
+    assert jnp.all(jnp.isfinite(a))
+    assert jnp.isfinite(b)
+
+    norm_sq = float(a @ a)
+    if norm_sq > 1e-10:
+        scale = (abs(float(b)) + 1.0) / (norm_sq + 1e-12) + 1.0
+        mu = -scale * a
+    else:
+        mu = -jnp.ones_like(a) * (abs(float(b)) + 1.0)
+
+    value = float(a @ mu + b)
+    assert value < -1e-6


### PR DESCRIPTION
## Summary
- implement the equity constraint coefficient construction following Creal & Wu (2017)
- add a helper for computing the M0^Q mapping from Appendix A.2
- cover the new functionality with unit tests for the helper and inequality

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d15e1810dc8320b552013c391434f8