### PR TITLE
Add Block 3c state-space builders and sampler

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,3 @@
+"""State-space builders for alternative sampling blocks."""
+
+__all__ = ["ss_builders_3c"]

--- a/src/models/ss_builders_3c.py
+++ b/src/models/ss_builders_3c.py
@@ -1,0 +1,228 @@
+"""State-space builders for Block 3c sampling.
+
+The layouts follow Form I in Appendix B.1.1 of Creal & Wu (2017,
+*International Economic Review*) together with the yield rotations from
+Appendix A.2.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Tuple
+
+import jax.numpy as jnp
+
+from kalman import Step
+from utils.selectors import block_diag
+
+ArrayDict = Dict[str, jnp.ndarray]
+ConfigDict = Dict[str, Dict[str, int]]
+
+
+def _q_g_process_cov(
+    sigma_gm: jnp.ndarray, sigma_g: jnp.ndarray, d_g_t: jnp.ndarray
+) -> jnp.ndarray:
+    """Return ``Q_{g,t}`` for the :math:`g_t` innovation."""
+
+    sigma_gm64 = jnp.asarray(sigma_gm, dtype=jnp.float64)
+    sigma_g64 = jnp.asarray(sigma_g, dtype=jnp.float64)
+    diag_scale = jnp.asarray(d_g_t, dtype=jnp.float64)
+
+    sigma_g_scaled = sigma_g64 * diag_scale
+    return sigma_gm64 @ sigma_gm64.T + sigma_g_scaled @ sigma_g_scaled.T
+
+
+def build_steps_augmented(
+    fixed: ArrayDict,
+    data: ArrayDict,
+    cfg: ConfigDict,
+    priors: ArrayDict,
+    state: Dict,
+) -> Tuple[Callable[[int], Step], jnp.ndarray, jnp.ndarray, Dict[str, slice]]:
+    """Return the Form I LDS with static means kept in the state.
+
+    The construction follows Appendix B.1.1 (Form I) of Creal & Wu (2017,
+    *International Economic Review*) while mapping the measurement block using
+    the rotations from Appendix A.2.
+    """
+
+    dims = cfg["dims"]
+    d_m = int(dims["d_m"])
+    d_g = int(dims["d_g"])
+    d_h = int(dims["d_h"])
+    d_y = int(dims["d_y"])
+
+    phi_g = jnp.asarray(fixed["Phi_g"], dtype=jnp.float64)
+    phi_gm = jnp.asarray(fixed["Phi_gm"], dtype=jnp.float64)
+    phi_gh = jnp.asarray(fixed["Phi_gh"], dtype=jnp.float64)
+
+    bar_blocks = fixed["bar"]
+    bar_gm = jnp.asarray(bar_blocks["gm"], dtype=jnp.float64)
+    bar_gg = jnp.asarray(bar_blocks["gg"], dtype=jnp.float64)
+    bar_gh = jnp.asarray(bar_blocks["gh"], dtype=jnp.float64)
+
+    m1 = jnp.asarray(fixed["M1"], dtype=jnp.float64)
+    m1_q = jnp.asarray(fixed["M1Q"], dtype=jnp.float64)
+    m0_q = jnp.asarray(fixed["M0Q"], dtype=jnp.float64)
+
+    a0 = jnp.asarray(fixed["A0"], dtype=jnp.float64)
+    a1 = jnp.asarray(fixed["A1"], dtype=jnp.float64)
+    b_mat = jnp.asarray(fixed["B"], dtype=jnp.float64)
+    omega_diag = jnp.asarray(fixed["Omega_diag"], dtype=jnp.float64)
+
+    mu_h_bar = jnp.asarray(fixed["mu_h_bar"], dtype=jnp.float64)
+
+    sigma_gm = jnp.asarray(fixed["Sigma_gm"], dtype=jnp.float64)
+    sigma_g = jnp.asarray(fixed["Sigma_g"], dtype=jnp.float64)
+
+    m_obs = jnp.asarray(data["m"], dtype=jnp.float64)
+    h_obs = jnp.asarray(data["h"], dtype=jnp.float64)
+    d_g_series = jnp.asarray(data["Dg"], dtype=jnp.float64)
+
+    idx_g = slice(0, d_g)
+    idx_mu_m = slice(d_g, d_g + d_m)
+    idx_mu_gu = slice(d_g + d_m, d_g + d_m + 2)
+    idx_mu_gq = slice(d_g + d_m + 2, d_g + d_m + 4)
+    idx_static = slice(d_g, d_g + d_m + 4)
+
+    g0_mean = jnp.asarray(
+        state.get("g0_mean", jnp.zeros((d_g,), dtype=jnp.float64)),
+        dtype=jnp.float64,
+    )
+    g0_cov = jnp.asarray(
+        state.get("g0_cov", jnp.eye(d_g, dtype=jnp.float64) * 1e-2),
+        dtype=jnp.float64,
+    )
+
+    mu_m_mean = jnp.asarray(priors["mu_m_mean"], dtype=jnp.float64)
+    mu_m_cov = jnp.asarray(priors["mu_m_cov"], dtype=jnp.float64)
+    mu_gu_mean = jnp.asarray(priors["mu_gu_mean"], dtype=jnp.float64)
+    mu_gu_cov = jnp.asarray(priors["mu_gu_cov"], dtype=jnp.float64)
+    mu_gq_mean = jnp.asarray(priors["mu_gQu_mean"], dtype=jnp.float64)
+    mu_gq_cov = jnp.asarray(priors["mu_gQu_cov"], dtype=jnp.float64)
+
+    x0_mean = jnp.concatenate([g0_mean, mu_m_mean, mu_gu_mean, mu_gq_mean])
+    x0_cov = block_diag(g0_cov, mu_m_cov, mu_gu_cov, mu_gq_cov)
+
+    h_mat = jnp.diag(omega_diag)
+    z_template = jnp.zeros((d_y, d_g + d_m + 4), dtype=jnp.float64)
+    z_template = z_template.at[:, idx_g].set(b_mat)
+    z_template = z_template.at[:, idx_mu_gq].set(a1 @ m1_q)
+
+    t_template = jnp.eye(d_g + d_m + 4, dtype=jnp.float64)
+    t_template = t_template.at[idx_g, idx_g].set(phi_g)
+    t_template = t_template.at[idx_g, idx_mu_m].set(bar_gm)
+    t_template = t_template.at[idx_g, idx_mu_gu].set(bar_gg @ m1)
+
+    r_template = jnp.zeros((d_g + d_m + 4, d_g), dtype=jnp.float64)
+    r_template = r_template.at[idx_g, :].set(jnp.eye(d_g, dtype=jnp.float64))
+
+    d_vec = a0 + a1 @ m0_q
+
+    def steps(t: int) -> Step:
+        q_g = _q_g_process_cov(sigma_gm, sigma_g, d_g_series[t])
+
+        c_vec = jnp.zeros((d_g + d_m + 4,), dtype=jnp.float64)
+        c_top = phi_gm @ m_obs[t] + phi_gh @ h_obs[t] + bar_gh @ mu_h_bar
+        c_vec = c_vec.at[idx_g].set(c_top)
+
+        return Step(
+            Z=z_template,
+            d=d_vec,
+            H=h_mat,
+            T=t_template,
+            c=c_vec,
+            R=r_template,
+            Q=q_g,
+        )
+
+    slices = {
+        "g": idx_g,
+        "mu_m": idx_mu_m,
+        "mu_gu": idx_mu_gu,
+        "mu_gQ_u": idx_mu_gq,
+        "static_all": idx_static,
+    }
+
+    return steps, x0_mean, x0_cov, slices
+
+
+def build_steps_reduced(
+    fixed: ArrayDict,
+    data: ArrayDict,
+    cfg: ConfigDict,
+    mus: Dict[str, jnp.ndarray],
+) -> Tuple[Callable[[int], Step], jnp.ndarray, jnp.ndarray]:
+    """Return the Form I LDS with static means absorbed into the offsets."""
+
+    dims = cfg["dims"]
+    d_m = int(dims["d_m"])
+    d_g = int(dims["d_g"])
+    d_h = int(dims["d_h"])
+    d_y = int(dims["d_y"])
+
+    phi_g = jnp.asarray(fixed["Phi_g"], dtype=jnp.float64)
+    phi_gm = jnp.asarray(fixed["Phi_gm"], dtype=jnp.float64)
+    phi_gh = jnp.asarray(fixed["Phi_gh"], dtype=jnp.float64)
+
+    bar_blocks = fixed["bar"]
+    bar_gm = jnp.asarray(bar_blocks["gm"], dtype=jnp.float64)
+    bar_gg = jnp.asarray(bar_blocks["gg"], dtype=jnp.float64)
+    bar_gh = jnp.asarray(bar_blocks["gh"], dtype=jnp.float64)
+
+    m1 = jnp.asarray(fixed["M1"], dtype=jnp.float64)
+    m1_q = jnp.asarray(fixed["M1Q"], dtype=jnp.float64)
+    m0_q = jnp.asarray(fixed["M0Q"], dtype=jnp.float64)
+
+    a0 = jnp.asarray(fixed["A0"], dtype=jnp.float64)
+    a1 = jnp.asarray(fixed["A1"], dtype=jnp.float64)
+    b_mat = jnp.asarray(fixed["B"], dtype=jnp.float64)
+    omega_diag = jnp.asarray(fixed["Omega_diag"], dtype=jnp.float64)
+
+    mu_h_bar = jnp.asarray(fixed["mu_h_bar"], dtype=jnp.float64)
+
+    sigma_gm = jnp.asarray(fixed["Sigma_gm"], dtype=jnp.float64)
+    sigma_g = jnp.asarray(fixed["Sigma_g"], dtype=jnp.float64)
+
+    m_obs = jnp.asarray(data["m"], dtype=jnp.float64)
+    h_obs = jnp.asarray(data["h"], dtype=jnp.float64)
+    d_g_series = jnp.asarray(data["Dg"], dtype=jnp.float64)
+
+    mu_m = jnp.asarray(mus["mu_m"], dtype=jnp.float64)
+    mu_gu = jnp.asarray(mus["mu_gu"], dtype=jnp.float64)
+    mu_gq = jnp.asarray(mus["mu_gQ_u"], dtype=jnp.float64)
+
+    mu_g = m1 @ mu_gu
+
+    z_mat = jnp.asarray(b_mat, dtype=jnp.float64)
+    h_mat = jnp.diag(omega_diag)
+    a1_m1q = a1 @ m1_q
+    d_vec = a0 + a1 @ m0_q + a1_m1q @ mu_gq
+
+    r_mat = jnp.eye(d_g, dtype=jnp.float64)
+
+    def steps(t: int) -> Step:
+        c_vec = (
+            phi_gm @ m_obs[t]
+            + phi_gh @ h_obs[t]
+            + bar_gm @ mu_m
+            + bar_gg @ mu_g
+            + bar_gh @ mu_h_bar
+        )
+        q_g = _q_g_process_cov(sigma_gm, sigma_g, d_g_series[t])
+
+        return Step(
+            Z=z_mat,
+            d=d_vec,
+            H=h_mat,
+            T=phi_g,
+            c=c_vec,
+            R=r_mat,
+            Q=q_g,
+        )
+
+    x0_mean = jnp.zeros((d_g,), dtype=jnp.float64)
+    x0_cov = jnp.eye(d_g, dtype=jnp.float64) * 1e-2
+    return steps, x0_mean, x0_cov
+
+
+__all__ = ["build_steps_augmented", "build_steps_reduced"]

--- a/src/samplers/block3c.py
+++ b/src/samplers/block3c.py
@@ -1,0 +1,99 @@
+"""Sampling block for the ``g`` factors and static means.
+
+Implements the Form I recursion from Appendix B.1.1 of Creal & Wu (2017,
+*International Economic Review*) with the Q-measure rotations described in
+Appendix A.2.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from equity_constraint import equity_coeffs
+from kalman import dk_sample, kf_forward
+from models.ss_builders_3c import build_steps_augmented, build_steps_reduced
+from samplers.trunc_gauss import sample_halfspace_trunc_normal
+from utils.linalg import chol_solve_spd, safe_cholesky
+
+
+def _loglike_from_cache(cache: Dict[str, jnp.ndarray]) -> jnp.ndarray:
+    """Compute the Gaussian log-likelihood from Kalman innovations."""
+
+    innov = jnp.asarray(cache["innov"], dtype=jnp.float64)
+    innov_cov = jnp.asarray(cache["innov_cov"], dtype=jnp.float64)
+
+    def _per_period(v: jnp.ndarray, s: jnp.ndarray) -> jnp.ndarray:
+        L = safe_cholesky(s)
+        solve = chol_solve_spd(L, v)
+        logdet = 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
+        dim = v.shape[0]
+        return -0.5 * (logdet + v @ solve + dim * jnp.log(2.0 * jnp.pi))
+
+    return jnp.sum(jax.vmap(_per_period)(innov, innov_cov))
+
+
+def run_block3c_dk_draw(
+    key: jax.random.KeyArray,
+    state: Dict,
+    fixed: Dict,
+    data: Dict,
+    cfg: Dict,
+    priors: Dict,
+) -> Tuple[Dict, Dict]:
+    """Draw ``g_{1:T}`` and the static means using the Form I sampler of Appendix B.1.1."""
+
+    y_obs = jnp.asarray(data["y"], dtype=jnp.float64)
+
+    key_mu, key_g = jax.random.split(key)
+
+    steps_aug, x0_mean_aug, x0_cov_aug, idx = build_steps_augmented(
+        fixed, data, cfg, priors, state
+    )
+    cache_aug = kf_forward(y_obs, steps_aug, x0_mean_aug, x0_cov_aug)
+
+    filt_mean_T = cache_aug["filt_mean"][-1]
+    filt_cov_T = cache_aug["filt_cov"][-1]
+
+    mu_mean = filt_mean_T[idx["static_all"]]
+    mu_cov = filt_cov_T[idx["static_all"], idx["static_all"]]
+    mu_cov = 0.5 * (mu_cov + mu_cov.T)
+
+    a_vec, b_val = equity_coeffs(fixed, cfg)
+    mu_draw = sample_halfspace_trunc_normal(key_mu, mu_mean, mu_cov, a_vec, b_val)
+
+    d_m = int(cfg["dims"]["d_m"])
+    mu_m = mu_draw[:d_m]
+    mu_gu = mu_draw[d_m : d_m + 2]
+    mu_gq = mu_draw[d_m + 2 : d_m + 4]
+
+    steps_red, x0_mean_red, x0_cov_red = build_steps_reduced(
+        fixed,
+        data,
+        cfg,
+        mus={"mu_m": mu_m, "mu_gu": mu_gu, "mu_gQ_u": mu_gq},
+    )
+    cache_red = kf_forward(y_obs, steps_red, x0_mean_red, x0_cov_red)
+    g_draw = dk_sample(key_g, y_obs, steps_red, x0_mean_red, x0_cov_red, cache_red)
+
+    loglik = _loglike_from_cache(cache_red)
+    max_abs_innov = jnp.max(jnp.abs(cache_red["innov"]))
+    slack = a_vec @ mu_draw + b_val
+
+    new_state = {
+        "g_path": g_draw,
+        "mu_m": mu_m,
+        "mu_g_u": mu_gu,
+        "mu_gQ_u": mu_gq,
+    }
+    diags = {
+        "loglik": loglik,
+        "max_abs_innov": max_abs_innov,
+        "constraint_slack": slack,
+    }
+    return new_state, diags
+
+
+__all__ = ["run_block3c_dk_draw"]


### PR DESCRIPTION
## Summary
- add a shared models package with Form I state-space builders for block 3c
- implement the block 3c sampler that draws static means under the equity constraint and DK-samples g

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d167aa05088320977e8375405f98c3