### PR TITLE
Add covariance block sampling with equity constraint enforcement

### DIFF
--- a/src/tsm/covariance_blocks.py
+++ b/src/tsm/covariance_blocks.py
@@ -1,0 +1,308 @@
+"""Recursive covariance block draws for the Gibbs sampler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+from numpy.random import Generator
+from scipy import linalg
+
+from .equity_constraint import equity_margin
+from .math_utils import (
+    ensure_spd_inverse,
+    iw_sample,
+    matrix_normal_sample,
+    safe_cholesky,
+    triangular_solve_unit_lower,
+)
+
+
+@dataclass
+class CovarianceDraw:
+    Sigma_m: np.ndarray
+    eps_m: np.ndarray
+    Sigma_gm: np.ndarray
+    eps_g: np.ndarray
+    Sigma_hm: np.ndarray
+    Sigma_hg: np.ndarray
+    Sigma_h: np.ndarray
+    constraint_rejects: int
+    constraint_used_fallback: bool
+
+
+@dataclass
+class TriangularRegressionPrior:
+    row_covariances: list[np.ndarray]
+
+
+@dataclass
+class MatrixNormalInverseWishartPrior:
+    M0: np.ndarray
+    V0: np.ndarray
+    S0: np.ndarray
+    nu0: float
+
+
+@dataclass
+class CovarianceBlockPriors:
+    rng: Generator
+    sigma_m: TriangularRegressionPrior
+    sigma_gm: TriangularRegressionPrior
+    sigma_h: MatrixNormalInverseWishartPrior
+
+
+@dataclass
+class EquityConstraintParams:
+    theta_m: np.ndarray
+    theta_g: np.ndarray
+    theta_g_Q: np.ndarray
+    mu_m_bar: np.ndarray
+    mu_g_u_bar: np.ndarray
+    mu_g_Q_u_bar: np.ndarray
+    mu_h_bar: np.ndarray
+    Phi_m: np.ndarray
+    Phi_mg: np.ndarray
+    Phi_mh: np.ndarray
+    Phi_h: np.ndarray
+    M0_Q: np.ndarray
+    M1_Q: np.ndarray
+    Sigma_g_Q: np.ndarray
+    Phi_g_Q: np.ndarray
+
+
+def _check_triangular_prior(prior: TriangularRegressionPrior, rows: int) -> None:
+    if len(prior.row_covariances) < rows:
+        raise ValueError("insufficient prior rows provided")
+
+
+def draw_sigma_m(
+    r_m: np.ndarray,
+    Dm: np.ndarray,
+    priors: CovarianceBlockPriors,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Model residuals (Appendix B.1):
+    Let
+
+    rtm ≡mt+1−μm−Φmmt−Φmggt−Φmhht(B.3)
+    rtg ≡gt+1−μg−Φgmmt−Φggt−Φghht(B.4)
+    rth ≡ht+1−μh−Φhht(B.5)
+
+    with shocks εm,εg,εh∼iidN(0,I) and
+
+    rtm =Σm diag(Dm,t) εm,t,
+    rtg =Σgmεm,t+Σg diag(Dg,t) εg,t,
+    rth =Σhmεm,t+Σhgεg,t+Σhεh,t.
+
+    Parameterize the precision transform Tm≡Σm−1, which is also unit lower-triangular. Then
+
+    εm,t=Tmutm,soui,tm=−βi⊤u1:i−1,tm+εm,i,t,  εm,i,t∼N(0,1),
+
+    where βi≡(Tm)i,1:i−1 and the diagonal of Tm is 1.
+    """
+
+    rng = priors.rng
+    T, d_m = r_m.shape
+    _check_triangular_prior(priors.sigma_m, d_m)
+
+    if Dm.shape != r_m.shape:
+        raise ValueError("Dm must match r_m in shape")
+
+    u = np.array(r_m / Dm, dtype=np.float64)
+    T_m = np.zeros((d_m, d_m), dtype=np.float64)
+    np.fill_diagonal(T_m, 1.0)
+
+    for i in range(1, d_m - 1):
+        cols = i
+        if cols == 0:
+            continue
+        X = -u[:, :cols]
+        y = u[:, i]
+        V0 = np.asarray(priors.sigma_m.row_covariances[i], dtype=np.float64)
+        if V0.shape != (cols, cols):
+            raise ValueError("prior covariance has incorrect shape for row")
+        V0_inv = ensure_spd_inverse(V0)
+        XtX = X.T @ X
+        precision = V0_inv + XtX
+        chol_precision = safe_cholesky(precision)
+        Vn = linalg.cho_solve((chol_precision, True), np.eye(cols))
+        mean = Vn @ (X.T @ y)
+        beta = rng.multivariate_normal(mean=mean, cov=Vn)
+        T_m[i, :cols] = beta
+
+    Sigma_m = triangular_solve_unit_lower(T_m, np.eye(d_m))
+    eps_m = u @ T_m.T
+    return Sigma_m, eps_m
+
+
+def draw_sigma_gm_and_eps_g(
+    r_g: np.ndarray,
+    Dg: np.ndarray,
+    Sigma_g: np.ndarray,
+    eps_m: np.ndarray,
+    priors: CovarianceBlockPriors,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Goal: draw Σgm honoring the recursion based on (B.4) and then compute εg.
+
+    From (B.4),
+
+    rtg=Σgmεm,t+Σg diag(Dg,t) εg,t.
+
+    Left-multiply by Σg−1 and divide rowwise by Dg,t:
+
+    zi,t≡ei⊤Σg−1rtgDg,i,t=(1Dg,i,tεm,t⊤)bi  +  εg,i,t,bi⊤≡ei⊤Σg−1Σgm.
+
+    For each i=1,…,dg, run a Gaussian regression of zi,⋅ on row-scaled εm to draw bi.
+    Finally compute εg,i,t=zi,t−Xi,tbi for all i,t.
+    """
+
+    rng = priors.rng
+    T, d_g = r_g.shape
+    d_m = eps_m.shape[1]
+    _check_triangular_prior(priors.sigma_gm, d_g)
+
+    if Dg.shape != r_g.shape:
+        raise ValueError("Dg must match r_g in shape")
+    if Sigma_g.shape[0] != d_g or Sigma_g.shape[1] != d_g:
+        raise ValueError("Sigma_g must be square with dimension d_g")
+
+    z = np.empty_like(r_g, dtype=np.float64)
+    for t in range(T):
+        vec = linalg.solve_triangular(
+            Sigma_g,
+            r_g[t],
+            lower=True,
+            unit_diagonal=True,
+            check_finite=False,
+        )
+        z[t] = vec / Dg[t]
+
+    B = np.zeros((d_g, d_m), dtype=np.float64)
+    eps_g = np.zeros((T, d_g), dtype=np.float64)
+
+    for i in range(d_g):
+        X = eps_m / Dg[:, i][:, None]
+        y = z[:, i]
+        V0 = np.asarray(priors.sigma_gm.row_covariances[i], dtype=np.float64)
+        if V0.shape != (d_m, d_m):
+            raise ValueError("prior covariance has incorrect shape for Sigma_gm row")
+        V0_inv = ensure_spd_inverse(V0)
+        XtX = X.T @ X
+        precision = V0_inv + XtX
+        chol_precision = safe_cholesky(precision)
+        Vn = linalg.cho_solve((chol_precision, True), np.eye(d_m))
+        mean = Vn @ (X.T @ y)
+        b = rng.multivariate_normal(mean=mean, cov=Vn)
+        B[i] = b
+        eps_g[:, i] = y - X @ b
+
+    Sigma_gm = Sigma_g @ B
+    return Sigma_gm, eps_g
+
+
+def draw_sigma_h_block_with_constraint(
+    r_h: np.ndarray,
+    eps_m: np.ndarray,
+    eps_g: np.ndarray,
+    equity_params: EquityConstraintParams,
+    priors: CovarianceBlockPriors,
+    max_rejects: int = 200,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, dict]:
+    """
+    Goal: jointly draw (Σhm,Σhg,Σh) from the conjugate multivariate regression implied by (B.5),
+    truncated to the set where your equity inequality holds.
+
+    Let Xt≡[εm,t⊤  εg,t⊤]∈Rdm+dg, Yt≡rth∈Rdh. Stack into X∈RT×(dm+dg), Y∈RT×dh. The regression is
+
+    Y=XB⊤+E,Et⋅∼N(0, ΣhΣh⊤),
+
+    with B=[Σhm Σhg]∈Rdh×(dm+dg). Use matrix-normal–inverse-Wishart prior
+
+    B∣Σh∼MN(M0, ΣhΣh⊤, V0),ΣhΣh⊤∼IW(ν0,S0).
+
+    Posterior (closed form):
+
+    Vn =(V0−1+X⊤X)−1,Mn=(Y⊤X) Vn,
+    Sn =S0+Y⊤Y+M0⊤V0−1M0−Mn⊤Vn−1Mn,
+    νn =ν0+T.
+
+    Draw ΣhΣh⊤∼IW(νn,Sn), set Σh=chol(ΣhΣh⊤), then draw B∼MN(Mn, ΣhΣh⊤, Vn) and split B→(Σhm,Σhg).
+
+    Hard equity constraint (truncate): reject draws where the inequality margin is non-negative.
+    """
+
+    rng = priors.rng
+    T, d_h = r_h.shape
+    d_m = eps_m.shape[1]
+    d_g = eps_g.shape[1]
+
+    X = np.hstack([eps_m, eps_g])
+    Y = np.array(r_h, dtype=np.float64)
+
+    M0 = np.asarray(priors.sigma_h.M0, dtype=np.float64)
+    V0 = np.asarray(priors.sigma_h.V0, dtype=np.float64)
+    S0 = np.asarray(priors.sigma_h.S0, dtype=np.float64)
+    nu0 = float(priors.sigma_h.nu0)
+
+    if M0.shape != (d_h, d_m + d_g):
+        raise ValueError("M0 has incorrect shape")
+    if V0.shape != (d_m + d_g, d_m + d_g):
+        raise ValueError("V0 has incorrect shape")
+    if S0.shape != (d_h, d_h):
+        raise ValueError("S0 has incorrect shape")
+
+    V0_inv = ensure_spd_inverse(V0)
+    XtX = X.T @ X
+    precision = V0_inv + XtX
+    chol_precision = safe_cholesky(precision)
+    Vn = linalg.cho_solve((chol_precision, True), np.eye(d_m + d_g))
+    Mn = (Y.T @ X) @ Vn
+    prior_term = M0 @ (V0_inv @ M0.T)
+    post_term = Mn @ (precision @ Mn.T)
+    Sn = S0 + Y.T @ Y + prior_term - post_term
+    Sn = (Sn + Sn.T) / 2.0
+    nu_n = nu0 + T
+
+    rejects = 0
+    used_fallback = False
+
+    while True:
+        Sigma_h_cov = iw_sample(rng, nu_n, Sn)
+        Sigma_h = safe_cholesky(Sigma_h_cov)
+        B = matrix_normal_sample(rng, Mn, Sigma_h_cov, Vn)
+        Sigma_hm = B[:, :d_m]
+        Sigma_hg = B[:, d_m:]
+        margin = equity_margin(
+            equity_params.theta_m,
+            equity_params.theta_g,
+            equity_params.theta_g_Q,
+            equity_params.mu_m_bar,
+            equity_params.mu_g_u_bar,
+            equity_params.mu_g_Q_u_bar,
+            equity_params.Phi_m,
+            equity_params.Phi_mg,
+            equity_params.Phi_mh,
+            equity_params.Phi_h,
+            equity_params.M0_Q,
+            equity_params.M1_Q,
+            equity_params.Sigma_g_Q,
+            Sigma_hm,
+            Sigma_hg,
+            Sigma_h,
+            equity_params.mu_h_bar,
+            equity_params.Phi_g_Q,
+        )
+        if margin < 0.0:
+            break
+        rejects += 1
+        if rejects > max_rejects:
+            raise RuntimeError("Equity constraint too tight; rejection limit reached")
+
+    diagnostics = {
+        "constraint_rejects": rejects,
+        "constraint_used_fallback": used_fallback,
+    }
+    return Sigma_hm, Sigma_hg, Sigma_h, diagnostics

--- a/src/tsm/equity_constraint.py
+++ b/src/tsm/equity_constraint.py
@@ -1,0 +1,97 @@
+"""Equity inequality margin for the covariance block sampler."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy import linalg
+
+
+def equity_margin(
+    theta_m: np.ndarray,
+    theta_g: np.ndarray,
+    theta_g_Q: np.ndarray,
+    mu_m_bar: np.ndarray,
+    mu_g_u_bar: np.ndarray,
+    mu_g_Q_u_bar: np.ndarray,
+    Phi_m: np.ndarray,
+    Phi_mg: np.ndarray,
+    Phi_mh: np.ndarray,
+    Phi_h: np.ndarray,
+    M0_Q: np.ndarray,
+    M1_Q: np.ndarray,
+    Sigma_g_Q: np.ndarray,
+    Sigma_hm: np.ndarray,
+    Sigma_hg: np.ndarray,
+    Sigma_h: np.ndarray,
+    mu_h_bar: np.ndarray,
+    Phi_g_Q: np.ndarray,
+) -> float:
+    """
+    Returns LHS = theta_m mu_m_bar + theta_g mu_g_u_bar + theta_g_Q mu_g_Q_u_bar + V(...)
+    where
+    V = [e_d'(I-Phi_m)^{-1}Phi_mh_bar + e_d' Phi_mh Phi_h_bar] mu_h_bar
+        + [e_d'(I-Phi_m)^{-1}Phi_mg - e_1'] M0_Q
+        + 1/2 [e_d'(I-Phi_m)^{-1}Phi_mg - e_1'] (I-Phi_g^Q)^{-1} Sigma_g^Q(
+              [e_d'(I-Phi_m)^{-1}Phi_mg - e_1'] (I-Phi_g^Q)^{-1} Sigma_g^Q
+              + e_d' Phi_mh Sigma_hg )
+        + 1/2 e_d' Phi_mh [Sigma_hm Sigma_hm' + Sigma_h Sigma_h'] Phi_mh' e_d
+        + 1/2 (e_d' Phi_mh Sigma_hg)(e_d' Phi_mh Sigma_hg)'.
+    """
+
+    theta_m = np.asarray(theta_m, dtype=np.float64)
+    theta_g = np.asarray(theta_g, dtype=np.float64)
+    theta_g_Q = np.asarray(theta_g_Q, dtype=np.float64)
+    mu_m_bar = np.asarray(mu_m_bar, dtype=np.float64)
+    mu_g_u_bar = np.asarray(mu_g_u_bar, dtype=np.float64)
+    mu_g_Q_u_bar = np.asarray(mu_g_Q_u_bar, dtype=np.float64)
+    Phi_m = np.asarray(Phi_m, dtype=np.float64)
+    Phi_mg = np.asarray(Phi_mg, dtype=np.float64)
+    Phi_mh = np.asarray(Phi_mh, dtype=np.float64)
+    Phi_h = np.asarray(Phi_h, dtype=np.float64)
+    M0_Q = np.asarray(M0_Q, dtype=np.float64)
+    Sigma_g_Q = np.asarray(Sigma_g_Q, dtype=np.float64)
+    Sigma_hm = np.asarray(Sigma_hm, dtype=np.float64)
+    Sigma_hg = np.asarray(Sigma_hg, dtype=np.float64)
+    Sigma_h = np.asarray(Sigma_h, dtype=np.float64)
+    mu_h_bar = np.asarray(mu_h_bar, dtype=np.float64)
+    Phi_g_Q = np.asarray(Phi_g_Q, dtype=np.float64)
+
+    d_m = Phi_m.shape[0]
+    d_g = Sigma_g_Q.shape[0]
+    e_d = np.zeros(d_m, dtype=np.float64)
+    e_d[-1] = 1.0
+    e1 = np.zeros(d_g, dtype=np.float64)
+    e1[0] = 1.0
+
+    I_m = np.eye(d_m, dtype=np.float64)
+    solve_m = linalg.solve(I_m - Phi_m, I_m, assume_a="gen", check_finite=False)
+
+    d_h = Phi_h.shape[0]
+    I_h = np.eye(d_h, dtype=np.float64)
+    Phi_h_bar = linalg.solve(I_h - Phi_h, I_h, assume_a="gen", check_finite=False)
+    Phi_mh_bar = Phi_mh @ Phi_h_bar
+
+    term1_vec = e_d @ solve_m @ Phi_mh_bar + e_d @ Phi_mh @ Phi_h_bar
+    term1 = float(term1_vec @ mu_h_bar)
+
+    row_q = e_d @ solve_m @ Phi_mg - e1
+    term2 = float(row_q @ M0_Q)
+
+    I_g = np.eye(d_g, dtype=np.float64)
+    solve_g = linalg.solve(I_g - Phi_g_Q, Sigma_g_Q, assume_a="gen", check_finite=False)
+    vec = row_q @ solve_g
+
+    add = (e_d @ Phi_mh) @ Sigma_hg
+    term3 = 0.5 * float(vec @ (vec + add))
+
+    Sigma_block = Sigma_hm @ Sigma_hm.T + Sigma_h @ Sigma_h.T
+    middle = (e_d @ Phi_mh) @ Sigma_block @ (Phi_mh.T @ e_d)
+    term4 = 0.5 * float(middle)
+
+    term5 = 0.5 * float(add @ add)
+
+    V = term1 + term2 + term3 + term4 + term5
+
+    const = float(theta_m @ mu_m_bar + theta_g @ mu_g_u_bar + theta_g_Q @ mu_g_Q_u_bar)
+
+    return const + V

--- a/src/tsm/math_utils.py
+++ b/src/tsm/math_utils.py
@@ -1,0 +1,102 @@
+"""Linear algebra utilities for covariance block sampling."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from numpy.random import Generator
+from scipy import linalg
+
+
+def safe_cholesky(matrix: np.ndarray, *, jitter: float = 1e-12, max_attempts: int = 6) -> np.ndarray:
+    """Return the lower Cholesky factor using adaptive jitter."""
+
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("matrix must be square")
+    attempt = 0
+    current = np.array(matrix, dtype=np.float64, copy=True)
+    jitter_scale = 1.0
+    while attempt < max_attempts:
+        try:
+            return np.linalg.cholesky(current)
+        except np.linalg.LinAlgError:
+            diag_indices = np.diag_indices_from(current)
+            current[diag_indices] += jitter * jitter_scale
+            jitter_scale *= 10.0
+            attempt += 1
+    raise np.linalg.LinAlgError("Cholesky decomposition failed even after jitter")
+
+
+def triangular_solve_unit_lower(tril: np.ndarray, rhs: np.ndarray) -> np.ndarray:
+    """Solve ``tril @ x = rhs`` for unit-lower-triangular ``tril``."""
+
+    if tril.ndim != 2 or tril.shape[0] != tril.shape[1]:
+        raise ValueError("tril must be square")
+    return linalg.solve_triangular(tril, rhs, lower=True, unit_diagonal=True, check_finite=False)
+
+
+def _bartlett_factor(rng: Generator, df: float, dim: int) -> np.ndarray:
+    if df <= dim - 1:
+        raise ValueError("degrees of freedom must exceed dim - 1")
+    a = np.zeros((dim, dim), dtype=np.float64)
+    for i in range(dim):
+        a[i, i] = math.sqrt(rng.chisquare(df - i))
+        for j in range(i):
+            a[i, j] = rng.normal()
+    return a
+
+
+def iw_sample(rng: Generator, df: float, scale: np.ndarray) -> np.ndarray:
+    """Draw from ``IW(df, scale)`` using Bartlett decomposition."""
+
+    if scale.ndim != 2 or scale.shape[0] != scale.shape[1]:
+        raise ValueError("scale must be square")
+    dim = scale.shape[0]
+    scale = np.array(scale, dtype=np.float64, copy=True)
+    chol_scale = safe_cholesky(scale)
+    inv_chol = linalg.solve_triangular(chol_scale, np.eye(dim), lower=True, check_finite=False)
+    bartlett = _bartlett_factor(rng, df, dim)
+    mat = inv_chol @ bartlett
+    wishart_sample = mat @ mat.T
+    chol_wishart = safe_cholesky(wishart_sample)
+    inv_sample = linalg.cho_solve((chol_wishart, True), np.eye(dim))
+    return (inv_sample + inv_sample.T) / 2.0
+
+
+def matrix_normal_sample(
+    rng: Generator,
+    mean: np.ndarray,
+    row_cov: np.ndarray,
+    col_cov: np.ndarray,
+) -> np.ndarray:
+    """Sample from ``MN(mean, row_cov, col_cov)``."""
+
+    mean = np.array(mean, dtype=np.float64, copy=False)
+    row_cov = np.array(row_cov, dtype=np.float64, copy=False)
+    col_cov = np.array(col_cov, dtype=np.float64, copy=False)
+
+    if mean.ndim != 2:
+        raise ValueError("mean must be a matrix")
+    if row_cov.ndim != 2 or row_cov.shape[0] != row_cov.shape[1]:
+        raise ValueError("row_cov must be square")
+    if col_cov.ndim != 2 or col_cov.shape[0] != col_cov.shape[1]:
+        raise ValueError("col_cov must be square")
+    if mean.shape[0] != row_cov.shape[0]:
+        raise ValueError("row dimension mismatch")
+    if mean.shape[1] != col_cov.shape[0]:
+        raise ValueError("column dimension mismatch")
+
+    chol_row = safe_cholesky(row_cov)
+    chol_col = safe_cholesky(col_cov)
+    z = rng.standard_normal(size=mean.shape)
+    sample = mean + chol_row @ z @ chol_col.T
+    return sample
+
+
+def ensure_spd_inverse(matrix: np.ndarray) -> np.ndarray:
+    """Compute the inverse of an SPD matrix via Cholesky solves."""
+
+    chol = safe_cholesky(matrix)
+    inv = linalg.cho_solve((chol, True), np.eye(matrix.shape[0]))
+    return (inv + inv.T) / 2.0

--- a/tests/test_covariance_blocks.py
+++ b/tests/test_covariance_blocks.py
@@ -1,0 +1,314 @@
+"""Unit tests for covariance block draws with equity constraint."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tsm.covariance_blocks import (
+    CovarianceBlockPriors,
+    EquityConstraintParams,
+    MatrixNormalInverseWishartPrior,
+    TriangularRegressionPrior,
+    draw_sigma_gm_and_eps_g,
+    draw_sigma_h_block_with_constraint,
+    draw_sigma_m,
+)
+from tsm.equity_constraint import equity_margin
+
+
+D_M = 5
+D_G = 3
+D_H = 7
+T_SMALL = 200
+
+
+def _make_setup(seed: int = 0):
+    rng = np.random.default_rng(seed)
+
+    Dm = rng.uniform(0.8, 1.2, size=(T_SMALL, D_M))
+    Dg = rng.uniform(0.8, 1.2, size=(T_SMALL, D_G))
+
+    Sigma_m_true = np.eye(D_M)
+    for i in range(1, D_M - 1):
+        Sigma_m_true[i, :i] = 0.15 * rng.standard_normal(i)
+    Sigma_m_true[-1, :-1] = 0.0
+    Sigma_m_true[-1, -1] = 1.0
+
+    Sigma_g = np.eye(D_G)
+    for i in range(1, D_G):
+        Sigma_g[i, :i] = 0.1 * rng.standard_normal(i)
+
+    Sigma_gm_true = 0.05 * rng.standard_normal((D_G, D_M))
+    base_h = 0.08 * rng.standard_normal((D_H, D_H))
+    Sigma_h_true = np.tril(base_h)
+    diag = np.abs(np.diag(Sigma_h_true)) + 0.5
+    np.fill_diagonal(Sigma_h_true, diag)
+    Sigma_hm_true = 0.05 * rng.standard_normal((D_H, D_M))
+    Sigma_hg_true = 0.05 * rng.standard_normal((D_H, D_G))
+
+    eps_m = rng.standard_normal((T_SMALL, D_M))
+    eps_g = rng.standard_normal((T_SMALL, D_G))
+    eps_h = rng.standard_normal((T_SMALL, D_H))
+
+    r_m = np.empty((T_SMALL, D_M))
+    r_g = np.empty((T_SMALL, D_G))
+    r_h = np.empty((T_SMALL, D_H))
+    for t in range(T_SMALL):
+        r_m[t] = Sigma_m_true @ (Dm[t] * eps_m[t])
+        r_g[t] = Sigma_gm_true @ eps_m[t] + Sigma_g @ (Dg[t] * eps_g[t])
+        r_h[t] = (
+            Sigma_hm_true @ eps_m[t]
+            + Sigma_hg_true @ eps_g[t]
+            + Sigma_h_true @ eps_h[t]
+        )
+
+    row_covs_m = [np.zeros((0, 0))]
+    for i in range(1, D_M):
+        row_covs_m.append(np.eye(i) * 100.0)
+    sigma_m_prior = TriangularRegressionPrior(row_covariances=row_covs_m)
+
+    row_covs_gm = [np.eye(D_M) * 100.0 for _ in range(D_G)]
+    sigma_gm_prior = TriangularRegressionPrior(row_covariances=row_covs_gm)
+
+    M0 = np.zeros((D_H, D_M + D_G))
+    V0 = np.eye(D_M + D_G) * 10.0
+    S0 = np.eye(D_H) * 1e-6
+    sigma_h_prior = MatrixNormalInverseWishartPrior(M0=M0, V0=V0, S0=S0, nu0=D_H + 5.0)
+
+    priors = CovarianceBlockPriors(
+        rng=rng,
+        sigma_m=sigma_m_prior,
+        sigma_gm=sigma_gm_prior,
+        sigma_h=sigma_h_prior,
+    )
+
+    Phi_m = 0.05 * rng.standard_normal((D_M, D_M))
+    Phi_mg = 0.05 * rng.standard_normal((D_M, D_G))
+    Phi_mh = 0.05 * rng.standard_normal((D_M, D_H))
+    Phi_h = 0.02 * rng.standard_normal((D_H, D_H))
+    Phi_g_Q = 0.03 * rng.standard_normal((D_G, D_G))
+
+    theta_m = np.zeros(D_M)
+    theta_m[0] = -5.0
+    theta_g = np.zeros(D_G)
+    theta_g_Q = np.zeros(D_G)
+    mu_m_bar = np.zeros(D_M)
+    mu_m_bar[0] = 1.0
+    mu_g_u_bar = np.zeros(D_G)
+    mu_g_Q_u_bar = np.zeros(D_G)
+    mu_h_bar = np.zeros(D_H)
+    M0_Q = np.zeros(D_G)
+    M1_Q = np.eye(D_G)
+    Sigma_g_Q = np.eye(D_G) * 0.5
+
+    equity_params = EquityConstraintParams(
+        theta_m=theta_m,
+        theta_g=theta_g,
+        theta_g_Q=theta_g_Q,
+        mu_m_bar=mu_m_bar,
+        mu_g_u_bar=mu_g_u_bar,
+        mu_g_Q_u_bar=mu_g_Q_u_bar,
+        mu_h_bar=mu_h_bar,
+        Phi_m=Phi_m,
+        Phi_mg=Phi_mg,
+        Phi_mh=Phi_mh,
+        Phi_h=Phi_h,
+        M0_Q=M0_Q,
+        M1_Q=M1_Q,
+        Sigma_g_Q=Sigma_g_Q,
+        Phi_g_Q=Phi_g_Q,
+    )
+
+    margin_true = equity_margin(
+        equity_params.theta_m,
+        equity_params.theta_g,
+        equity_params.theta_g_Q,
+        equity_params.mu_m_bar,
+        equity_params.mu_g_u_bar,
+        equity_params.mu_g_Q_u_bar,
+        equity_params.Phi_m,
+        equity_params.Phi_mg,
+        equity_params.Phi_mh,
+        equity_params.Phi_h,
+        equity_params.M0_Q,
+        equity_params.M1_Q,
+        equity_params.Sigma_g_Q,
+        Sigma_hm_true,
+        Sigma_hg_true,
+        Sigma_h_true,
+        equity_params.mu_h_bar,
+        equity_params.Phi_g_Q,
+    )
+    if margin_true >= -1.0:
+        theta_m = equity_params.theta_m.copy()
+        theta_m[0] -= margin_true + 2.0
+        equity_params.theta_m = theta_m
+
+    return {
+        "r_m": r_m,
+        "Dm": Dm,
+        "r_g": r_g,
+        "Dg": Dg,
+        "r_h": r_h,
+        "Sigma_g": Sigma_g,
+        "priors": priors,
+        "equity_params": equity_params,
+    }
+
+
+def test_covariance_draws_shapes_and_constraints():
+    setup = _make_setup(seed=123)
+
+    Sigma_m, eps_m = draw_sigma_m(setup["r_m"], setup["Dm"], setup["priors"])
+    Sigma_gm, eps_g = draw_sigma_gm_and_eps_g(
+        setup["r_g"],
+        setup["Dg"],
+        setup["Sigma_g"],
+        eps_m,
+        setup["priors"],
+    )
+    Sigma_hm, Sigma_hg, Sigma_h, diagnostics = draw_sigma_h_block_with_constraint(
+        setup["r_h"],
+        eps_m,
+        eps_g,
+        setup["equity_params"],
+        setup["priors"],
+        max_rejects=100,
+    )
+
+    assert np.allclose(Sigma_m, np.tril(Sigma_m))
+    assert np.allclose(np.diag(Sigma_m), 1.0)
+    assert np.allclose(Sigma_m[-1, :-1], 0.0)
+
+    assert np.isfinite(eps_m).all()
+    assert np.isfinite(eps_g).all()
+    var_eps_m = np.var(eps_m, axis=0)
+    var_eps_g = np.var(eps_g, axis=0)
+    assert np.all(np.abs(var_eps_m - 1.0) < 0.35)
+    assert np.all(np.abs(var_eps_g - 1.0) < 0.35)
+
+    assert np.allclose(Sigma_h, np.tril(Sigma_h))
+    assert np.all(np.diag(Sigma_h) > 0.0)
+
+    margin = equity_margin(
+        setup["equity_params"].theta_m,
+        setup["equity_params"].theta_g,
+        setup["equity_params"].theta_g_Q,
+        setup["equity_params"].mu_m_bar,
+        setup["equity_params"].mu_g_u_bar,
+        setup["equity_params"].mu_g_Q_u_bar,
+        setup["equity_params"].Phi_m,
+        setup["equity_params"].Phi_mg,
+        setup["equity_params"].Phi_mh,
+        setup["equity_params"].Phi_h,
+        setup["equity_params"].M0_Q,
+        setup["equity_params"].M1_Q,
+        setup["equity_params"].Sigma_g_Q,
+        Sigma_hm,
+        Sigma_hg,
+        Sigma_h,
+        setup["equity_params"].mu_h_bar,
+        setup["equity_params"].Phi_g_Q,
+    )
+    assert margin < 0.0
+
+    assert diagnostics["constraint_rejects"] >= 0
+    assert diagnostics["constraint_used_fallback"] is False
+
+
+def test_constraint_rejection_increments(monkeypatch):
+    setup = _make_setup(seed=456)
+
+    Sigma_m, eps_m = draw_sigma_m(setup["r_m"], setup["Dm"], setup["priors"])
+    Sigma_gm, eps_g = draw_sigma_gm_and_eps_g(
+        setup["r_g"],
+        setup["Dg"],
+        setup["Sigma_g"],
+        eps_m,
+        setup["priors"],
+    )
+
+    true_margin = equity_margin
+    counter = {"calls": 0}
+
+    def fake_margin(
+        theta_m,
+        theta_g,
+        theta_g_Q,
+        mu_m_bar,
+        mu_g_u_bar,
+        mu_g_Q_u_bar,
+        Phi_m,
+        Phi_mg,
+        Phi_mh,
+        Phi_h,
+        M0_Q,
+        M1_Q,
+        Sigma_g_Q,
+        Sigma_hm,
+        Sigma_hg,
+        Sigma_h,
+        mu_h_bar,
+        Phi_g_Q,
+    ):
+        counter["calls"] += 1
+        if counter["calls"] == 1:
+            return 1.0
+        return true_margin(
+            theta_m,
+            theta_g,
+            theta_g_Q,
+            mu_m_bar,
+            mu_g_u_bar,
+            mu_g_Q_u_bar,
+            Phi_m,
+            Phi_mg,
+            Phi_mh,
+            Phi_h,
+            M0_Q,
+            M1_Q,
+            Sigma_g_Q,
+            Sigma_hm,
+            Sigma_hg,
+            Sigma_h,
+            mu_h_bar,
+            Phi_g_Q,
+        )
+
+    monkeypatch.setattr("tsm.covariance_blocks.equity_margin", fake_margin)
+
+    Sigma_hm, Sigma_hg, Sigma_h, diagnostics = draw_sigma_h_block_with_constraint(
+        setup["r_h"],
+        eps_m,
+        eps_g,
+        setup["equity_params"],
+        setup["priors"],
+        max_rejects=100,
+    )
+
+    assert counter["calls"] >= 2
+    assert diagnostics["constraint_rejects"] >= 1
+    assert diagnostics["constraint_used_fallback"] is False
+
+    margin = true_margin(
+        setup["equity_params"].theta_m,
+        setup["equity_params"].theta_g,
+        setup["equity_params"].theta_g_Q,
+        setup["equity_params"].mu_m_bar,
+        setup["equity_params"].mu_g_u_bar,
+        setup["equity_params"].mu_g_Q_u_bar,
+        setup["equity_params"].Phi_m,
+        setup["equity_params"].Phi_mg,
+        setup["equity_params"].Phi_mh,
+        setup["equity_params"].Phi_h,
+        setup["equity_params"].M0_Q,
+        setup["equity_params"].M1_Q,
+        setup["equity_params"].Sigma_g_Q,
+        Sigma_hm,
+        Sigma_hg,
+        Sigma_h,
+        setup["equity_params"].mu_h_bar,
+        setup["equity_params"].Phi_g_Q,
+    )
+    assert margin < 0.0


### PR DESCRIPTION
## Summary
- add numerical utilities for safe Cholesky factors, inverse-Wishart, and matrix-normal sampling
- implement covariance block Gibbs draws with equity inequality checking
- provide equity margin helper and synthetic regression tests covering constraints and rejection handling

## Testing
- pytest tests/test_covariance_blocks.py

------
https://chatgpt.com/codex/tasks/task_e_68d1928fa3988320a55fb2099bc24046