### PR TITLE
Refactor Sigma_g^Q construction

### DIFF
--- a/src/equity_constraint.py
+++ b/src/equity_constraint.py
@@ -5,14 +5,19 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import jax.scipy.linalg
+import numpy as np
 
 from utils.selectors import e_last, e1
+from tsm.q_covariance import compute_sigma_g_Q
 
 
 def compute_M0Q_from_B_and_Sigma_gQ(
     B_rows: jnp.ndarray,
-    Sigma_gQ: jnp.ndarray,
     *,
+    Sigma_g: jnp.ndarray,
+    Gamma0: jnp.ndarray,
+    Gamma1: jnp.ndarray,
+    mu_h_bar: jnp.ndarray,
     n_star: int = 60,
 ) -> jnp.ndarray:
     r"""Return :math:`M_0^Q` using Appendix A.2 of Creal & Wu (2017).
@@ -22,8 +27,12 @@ def compute_M0Q_from_B_and_Sigma_gQ(
     B_rows:
         Matrix whose ``i``-th row stores :math:`b_{i,g}` for horizon ``i``. The
         matrix must include at least ``n_star - 1`` rows.
-    Sigma_gQ:
-        Rotation matrix :math:`\Sigma_g^Q` (Appendix A.2).
+    Sigma_g:
+        Lower-triangular matrix :math:`\Sigma_g` (Appendix B.4) whose Q-measure
+        rotation is constructed internally.
+    Gamma0, Gamma1, mu_h_bar:
+        Parameters determining the long-run diagonal scaling entering
+        :math:`\Sigma_g^Q`.
     n_star:
         Horizon count :math:`n^*` used for the annuity averaging.
 
@@ -37,16 +46,37 @@ def compute_M0Q_from_B_and_Sigma_gQ(
         raise ValueError("n_star must be at least 2")
 
     B64 = jnp.asarray(B_rows, dtype=jnp.float64)
-    Sigma64 = jnp.asarray(Sigma_gQ, dtype=jnp.float64)
-
     if B64.shape[0] < n_star - 1:
         raise ValueError("B_rows must have at least n_star - 1 rows")
     if B64.ndim != 2:
         raise ValueError("B_rows must be a matrix")
-    if Sigma64.ndim != 2 or Sigma64.shape[0] != Sigma64.shape[1]:
-        raise ValueError("Sigma_gQ must be square")
-    if B64.shape[1] != Sigma64.shape[0]:
-        raise ValueError("Column dimension mismatch between B_rows and Sigma_gQ")
+    Sigma_g_np = np.asarray(Sigma_g, dtype=np.float64)
+    Gamma0_np = np.asarray(Gamma0, dtype=np.float64)
+    Gamma1_np = np.asarray(Gamma1, dtype=np.float64)
+    mu_h_np = np.asarray(mu_h_bar, dtype=np.float64)
+
+    if Sigma_g_np.ndim != 2 or Sigma_g_np.shape[0] != Sigma_g_np.shape[1]:
+        raise ValueError("Sigma_g must be square")
+    if B64.shape[1] != Sigma_g_np.shape[0]:
+        raise ValueError("Column dimension mismatch between B_rows and Sigma_g")
+
+    d_g = Sigma_g_np.shape[0]
+    total = Gamma0_np.shape[0]
+    d_m = total - d_g
+    if d_m <= 0:
+        raise ValueError("Gamma0 must have length greater than d_g")
+    if Gamma1_np.shape != (total, mu_h_np.shape[0]):
+        raise ValueError("Gamma1 must have shape (d_m + d_g, d_h)")
+
+    Sigma_g_Q_np = compute_sigma_g_Q(
+        Sigma_g_np,
+        Gamma0_np,
+        Gamma1_np,
+        mu_h_np,
+        d_m,
+        d_g,
+    )
+    Sigma64 = jnp.asarray(Sigma_g_Q_np, dtype=jnp.float64)
 
     GG = Sigma64 @ Sigma64.T
     inner = jnp.float64(0.0)
@@ -75,11 +105,13 @@ def equity_coeffs(fixed: dict[str, jnp.ndarray], cfg: dict) -> tuple[jnp.ndarray
     Phi_mg = jnp.asarray(fixed["Phi_mg"], dtype=jnp.float64)
     Phi_mh = jnp.asarray(fixed["Phi_mh"], dtype=jnp.float64)
     Phi_gQ = jnp.asarray(fixed["Phi_gQ"], dtype=jnp.float64)
-    Sigma_gQ = jnp.asarray(fixed["Sigma_gQ"], dtype=jnp.float64)
     Sigma_h = jnp.asarray(fixed["Sigma_h"], dtype=jnp.float64)
     Sigma_hm = jnp.asarray(fixed["Sigma_hm"], dtype=jnp.float64)
     Sigma_hg = jnp.asarray(fixed["Sigma_hg"], dtype=jnp.float64)
     mu_hbar = jnp.asarray(fixed["mu_h_bar"], dtype=jnp.float64)
+    Sigma_g = np.asarray(fixed["Sigma_g"], dtype=np.float64)
+    Gamma0 = np.asarray(fixed["Gamma0"], dtype=np.float64)
+    Gamma1 = np.asarray(fixed["Gamma1"], dtype=np.float64)
 
     bar = fixed["bar"]
     bar_mm = jnp.asarray(bar["mm"], dtype=jnp.float64)
@@ -104,7 +136,18 @@ def equity_coeffs(fixed: dict[str, jnp.ndarray], cfg: dict) -> tuple[jnp.ndarray
     term1 = (e_d @ solve_Im_Phi_m @ bar_mh + e_d @ Phi_mh @ bar_hh) @ mu_hbar
     term2 = row_q @ M0Q
 
-    d_g = Phi_gQ.shape[0]
+    d_g = Sigma_g.shape[0]
+    Sigma_g_Q_np = compute_sigma_g_Q(
+        Sigma_g,
+        Gamma0,
+        Gamma1,
+        np.asarray(mu_hbar),
+        d_m,
+        d_g,
+    )
+    Sigma_gQ = jnp.asarray(Sigma_g_Q_np, dtype=jnp.float64)
+    if Phi_gQ.shape[0] != d_g:
+        raise ValueError("Phi_gQ dimension must match Sigma_g")
     Ig = jnp.eye(d_g, dtype=jnp.float64)
     S = jax.scipy.linalg.solve(Ig - Phi_gQ, Sigma_gQ, assume_a="gen")
     vec = row_q @ S

--- a/src/tsm/covariance_blocks.py
+++ b/src/tsm/covariance_blocks.py
@@ -68,7 +68,9 @@ class EquityConstraintParams:
     Phi_h: np.ndarray
     M0_Q: np.ndarray
     M1_Q: np.ndarray
-    Sigma_g_Q: np.ndarray
+    Sigma_g: np.ndarray
+    Gamma0: np.ndarray
+    Gamma1: np.ndarray
     Phi_g_Q: np.ndarray
 
 
@@ -288,7 +290,9 @@ def draw_sigma_h_block_with_constraint(
             equity_params.Phi_h,
             equity_params.M0_Q,
             equity_params.M1_Q,
-            equity_params.Sigma_g_Q,
+            equity_params.Sigma_g,
+            equity_params.Gamma0,
+            equity_params.Gamma1,
             Sigma_hm,
             Sigma_hg,
             Sigma_h,

--- a/src/tsm/q_covariance.py
+++ b/src/tsm/q_covariance.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+"""Utilities for constructing Q-measure covariances."""
+
+from typing import Tuple
+
+import numpy as np
+
+Array = np.ndarray
+
+
+def split_diag_mg(diag_vec: Array, d_m: int, d_g: int) -> Tuple[Array, Array]:
+    """Split a length-``(d_m + d_g)`` vector into ``(D_m, D_g)`` diagonal vectors."""
+
+    if diag_vec.shape != (d_m + d_g,):
+        raise ValueError("diag_vec must have shape (d_m + d_g,)")
+    return diag_vec[:d_m], diag_vec[d_m:]
+
+
+def compute_sigma_g_Q(
+    Sigma_g: Array,
+    Gamma0: Array,
+    Gamma1: Array,
+    mu_h_bar: Array,
+    d_m: int,
+    d_g: int,
+) -> Array:
+    """Return ``Sigma_g^Q = Sigma_g diag(\bar D_g)`` without inverting matrices.
+
+    The long-run diagonal scaling obeys
+
+    ``diag([\bar D_m; \bar D_g]) = exp((Gamma0 + Gamma1 mu_h_bar) / 2)``.
+
+    Parameters
+    ----------
+    Sigma_g:
+        Unit lower-triangular matrix for ``g`` innovations under ``P``.
+    Gamma0, Gamma1, mu_h_bar:
+        Long-run volatility mapping parameters.
+    d_m, d_g:
+        Dimensions for the macro and growth blocks.
+    """
+
+    xp = np
+    dtype = np.float64
+    try:
+        Sigma_g_arr = np.asarray(Sigma_g, dtype=dtype)
+        Gamma0_arr = np.asarray(Gamma0, dtype=dtype)
+        Gamma1_arr = np.asarray(Gamma1, dtype=dtype)
+        mu_h_arr = np.asarray(mu_h_bar, dtype=dtype)
+    except Exception as err:  # pragma: no cover - only hit under JAX tracing
+        try:
+            from jax.errors import TracerArrayConversionError
+        except ModuleNotFoundError as import_err:  # pragma: no cover - safety guard
+            raise err from import_err
+        if not isinstance(err, TracerArrayConversionError):
+            raise
+        import jax.numpy as jnp
+
+        xp = jnp
+        dtype = jnp.float64
+        Sigma_g_arr = jnp.asarray(Sigma_g, dtype=dtype)
+        Gamma0_arr = jnp.asarray(Gamma0, dtype=dtype)
+        Gamma1_arr = jnp.asarray(Gamma1, dtype=dtype)
+        mu_h_arr = jnp.asarray(mu_h_bar, dtype=dtype)
+
+    if Sigma_g_arr.shape != (d_g, d_g):
+        raise ValueError("Sigma_g must be square with shape (d_g, d_g)")
+    if Gamma0_arr.shape != (d_m + d_g,):
+        raise ValueError("Gamma0 must have length d_m + d_g")
+    if Gamma1_arr.shape != (d_m + d_g, mu_h_arr.shape[0]):
+        raise ValueError("Gamma1 must have shape (d_m + d_g, d_h)")
+
+    z_all = Gamma0_arr + Gamma1_arr @ mu_h_arr
+    diag_all = xp.exp(0.5 * z_all)
+    _, Dg_bar = split_diag_mg(diag_all, d_m, d_g)
+    return Sigma_g_arr @ xp.diag(Dg_bar)
+
+
+def _assert_spd_condition() -> None:
+    """Sanity check ensuring the implied covariance is SPD for valid inputs."""
+
+    d_m, d_g = 1, 2
+    Sigma_g = np.array([[1.1, 0.0], [0.2, 0.9]], dtype=np.float64)
+    Gamma0 = np.array([0.0, 0.1, -0.05], dtype=np.float64)
+    Gamma1 = np.array([[0.05], [0.02], [0.01]], dtype=np.float64)
+    mu_h_bar = np.array([0.3], dtype=np.float64)
+
+    Sigma_g_Q = compute_sigma_g_Q(Sigma_g, Gamma0, Gamma1, mu_h_bar, d_m, d_g)
+    cov = Sigma_g_Q @ Sigma_g_Q.T
+    eigvals = np.linalg.eigvalsh(cov)
+    assert np.all(eigvals > 0.0)
+
+
+_assert_spd_condition()
+

--- a/tests/test_block3a_smoke.py
+++ b/tests/test_block3a_smoke.py
@@ -21,13 +21,17 @@ def block3a_setup():
     h_t = jax.random.normal(h_key, (T, d_h), dtype=jnp.float64) * 0.1
     y_t = jax.random.normal(y_key, (T, d_y), dtype=jnp.float64) * 0.1
 
+    Sigma_g = jnp.eye(3, dtype=jnp.float64)
     fixed = {
         "m_t": m_t,
         "h_t": h_t,
         "mu_g": jnp.zeros(3, dtype=jnp.float64),
         "Q_g^Q": jnp.eye(3, dtype=jnp.float64),
         "Lambda_g^Q": jnp.diag(jnp.array([0.9, 0.8, 0.7], dtype=jnp.float64)),
-        "Sigma_g^Q": 0.01 * jnp.eye(3, dtype=jnp.float64),
+        "Sigma_g": Sigma_g,
+        "Gamma0": jnp.zeros(d_m + 3, dtype=jnp.float64),
+        "Gamma1": jnp.zeros((d_m + 3, d_h), dtype=jnp.float64),
+        "mu_h_bar": jnp.zeros(d_h, dtype=jnp.float64),
         "mu_g^{Q,u}": jnp.zeros(2, dtype=jnp.float64),
     }
     data = {"y_t": y_t}

--- a/tests/test_covariance_blocks.py
+++ b/tests/test_covariance_blocks.py
@@ -98,9 +98,10 @@ def _make_setup(seed: int = 0):
     mu_g_u_bar = np.zeros(D_G)
     mu_g_Q_u_bar = np.zeros(D_G)
     mu_h_bar = np.zeros(D_H)
+    Gamma0 = 0.01 * rng.standard_normal(D_M + D_G)
+    Gamma1 = 0.01 * rng.standard_normal((D_M + D_G, D_H))
     M0_Q = np.zeros(D_G)
     M1_Q = np.eye(D_G)
-    Sigma_g_Q = np.eye(D_G) * 0.5
 
     equity_params = EquityConstraintParams(
         theta_m=theta_m,
@@ -116,7 +117,9 @@ def _make_setup(seed: int = 0):
         Phi_h=Phi_h,
         M0_Q=M0_Q,
         M1_Q=M1_Q,
-        Sigma_g_Q=Sigma_g_Q,
+        Sigma_g=Sigma_g,
+        Gamma0=Gamma0,
+        Gamma1=Gamma1,
         Phi_g_Q=Phi_g_Q,
     )
 
@@ -133,7 +136,9 @@ def _make_setup(seed: int = 0):
         equity_params.Phi_h,
         equity_params.M0_Q,
         equity_params.M1_Q,
-        equity_params.Sigma_g_Q,
+        equity_params.Sigma_g,
+        equity_params.Gamma0,
+        equity_params.Gamma1,
         Sigma_hm_true,
         Sigma_hg_true,
         Sigma_h_true,
@@ -204,7 +209,9 @@ def test_covariance_draws_shapes_and_constraints():
         setup["equity_params"].Phi_h,
         setup["equity_params"].M0_Q,
         setup["equity_params"].M1_Q,
-        setup["equity_params"].Sigma_g_Q,
+        setup["equity_params"].Sigma_g,
+        setup["equity_params"].Gamma0,
+        setup["equity_params"].Gamma1,
         Sigma_hm,
         Sigma_hg,
         Sigma_h,
@@ -245,7 +252,9 @@ def test_constraint_rejection_increments(monkeypatch):
         Phi_h,
         M0_Q,
         M1_Q,
-        Sigma_g_Q,
+        Sigma_g,
+        Gamma0,
+        Gamma1,
         Sigma_hm,
         Sigma_hg,
         Sigma_h,
@@ -268,7 +277,9 @@ def test_constraint_rejection_increments(monkeypatch):
             Phi_h,
             M0_Q,
             M1_Q,
-            Sigma_g_Q,
+            Sigma_g,
+            Gamma0,
+            Gamma1,
             Sigma_hm,
             Sigma_hg,
             Sigma_h,
@@ -304,7 +315,9 @@ def test_constraint_rejection_increments(monkeypatch):
         setup["equity_params"].Phi_h,
         setup["equity_params"].M0_Q,
         setup["equity_params"].M1_Q,
-        setup["equity_params"].Sigma_g_Q,
+        setup["equity_params"].Sigma_g,
+        setup["equity_params"].Gamma0,
+        setup["equity_params"].Gamma1,
         Sigma_hm,
         Sigma_hg,
         Sigma_h,


### PR DESCRIPTION
## Summary
- add a shared tsm.q_covariance helper that derives \Sigma_g^Q from \Sigma_g, Gamma0, Gamma1, and \mu_h_bar
- update equity margin, CW2017 measurement code, and associated tests to require the primitive parameters instead of precomputed \Sigma_g^Q
- extend fixtures and dataclasses to carry Gamma0/Gamma1 values and persist \mu_h_bar while removing any standalone \Sigma_g^Q inputs

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d1aa811b208320aa5dcad92dc6dbb0