### PR TITLE
Scaffold bubble PM-HMC package

### DIFF
--- a/src/bubble/pmhmc/__init__.py
+++ b/src/bubble/pmhmc/__init__.py
@@ -1,0 +1,40 @@
+"""Scaffolding for the bubble particle MCMC (PM-HMC) package."""
+from __future__ import annotations
+
+from .prior import BubblePrior, gaussian_logpdf, isotropic_gaussian_logpdf
+from .transforms import (
+    artanh_unconstrain,
+    constrain_params,
+    from_unit_ball,
+    inv_softplus,
+    softplus,
+    tanh_constrain,
+    to_unit_ball,
+    unconstrain_params,
+)
+from .types import (
+    BubbleData,
+    BubbleParams,
+    BubbleParamsUnconstrained,
+    PMHMCConfig,
+    PMHMCResult,
+)
+
+__all__ = [
+    "BubbleData",
+    "BubbleParams",
+    "BubbleParamsUnconstrained",
+    "BubblePrior",
+    "PMHMCConfig",
+    "PMHMCResult",
+    "artanh_unconstrain",
+    "constrain_params",
+    "from_unit_ball",
+    "gaussian_logpdf",
+    "inv_softplus",
+    "isotropic_gaussian_logpdf",
+    "softplus",
+    "tanh_constrain",
+    "to_unit_ball",
+    "unconstrain_params",
+]

--- a/src/bubble/pmhmc/prior.py
+++ b/src/bubble/pmhmc/prior.py
@@ -1,0 +1,104 @@
+"""Prior helpers for the bubble PM-HMC module."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .types import BubbleParams
+
+LogScalarPrior = Callable[[float], float]
+LogRhoPrior = Callable[[NDArray[np.float_], NDArray[np.float_]], float]
+
+
+def _zero_scalar(_: float) -> float:
+    return 0.0
+
+
+def _zero_rho(_: NDArray[np.float_], __: NDArray[np.float_]) -> float:
+    return 0.0
+
+
+def gaussian_logpdf(value: float, *, mean: float = 0.0, scale: float = 1.0) -> float:
+    """Evaluate the log-density of a univariate Gaussian distribution."""
+
+    if scale <= 0.0:
+        raise ValueError("Scale must be strictly positive for a Gaussian prior.")
+    variance = scale ** 2
+    return -0.5 * (np.log(2.0 * np.pi * variance) + ((value - mean) ** 2) / variance)
+
+
+def isotropic_gaussian_logpdf(
+    rho_bm: NDArray[np.float_],
+    rho_bg: NDArray[np.float_],
+    *,
+    scale: float = 1.0,
+) -> float:
+    """Isotropic Gaussian log prior for the concatenated correlation vector."""
+
+    if scale <= 0.0:
+        raise ValueError("Scale must be strictly positive for the isotropic Gaussian prior.")
+    vec = np.concatenate((np.asarray(rho_bm, dtype=float), np.asarray(rho_bg, dtype=float)))
+    variance = scale ** 2
+    quad_form = float(np.dot(vec, vec))
+    dim = vec.size
+    return -0.5 * (dim * np.log(2.0 * np.pi * variance) + quad_form / variance)
+
+
+@dataclass(frozen=True)
+class BubblePrior:
+    """Composable log prior for :class:`~bubble.pmhmc.types.BubbleParams`."""
+
+    log_B0: LogScalarPrior = field(default=_zero_scalar)
+    log_mu_b: LogScalarPrior = field(default=_zero_scalar)
+    log_phi_b: LogScalarPrior = field(default=_zero_scalar)
+    log_sigma_h: LogScalarPrior = field(default=_zero_scalar)
+    log_rho: LogRhoPrior = field(default=_zero_rho)
+
+    def log_prob(self, params: BubbleParams) -> float:
+        """Return the total log prior probability for ``params``."""
+
+        return (
+            self.log_B0(params.B0)
+            + self.log_mu_b(params.mu_b)
+            + self.log_phi_b(params.phi_b)
+            + self.log_sigma_h(params.sigma_h)
+            + self.log_rho(params.rho_bm, params.rho_bg)
+        )
+
+    __call__ = log_prob
+
+    @classmethod
+    def flat(cls) -> BubblePrior:
+        """Create a prior with zero contribution from every parameter."""
+
+        return cls()
+
+    @classmethod
+    def gaussian(
+        cls,
+        *,
+        B0_scale: float = 1.0,
+        mu_b_scale: float = 1.0,
+        phi_b_scale: float = 1.0,
+        sigma_h_scale: float = 1.0,
+        rho_scale: float = 1.0,
+    ) -> BubblePrior:
+        """Construct a simple independent Gaussian prior for demonstration."""
+
+        return cls(
+            log_B0=lambda x: gaussian_logpdf(x, scale=B0_scale),
+            log_mu_b=lambda x: gaussian_logpdf(x, scale=mu_b_scale),
+            log_phi_b=lambda x: gaussian_logpdf(x, scale=phi_b_scale),
+            log_sigma_h=lambda x: gaussian_logpdf(x, scale=sigma_h_scale),
+            log_rho=lambda bm, bg: isotropic_gaussian_logpdf(bm, bg, scale=rho_scale),
+        )
+
+
+__all__ = [
+    "BubblePrior",
+    "gaussian_logpdf",
+    "isotropic_gaussian_logpdf",
+]

--- a/src/bubble/pmhmc/transforms.py
+++ b/src/bubble/pmhmc/transforms.py
@@ -1,0 +1,141 @@
+"""Parameter space transforms for the bubble PM-HMC module."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .types import BubbleParams, BubbleParamsUnconstrained
+
+ArrayLike = float | NDArray[np.float_]
+
+
+def _as_native_type(value: NDArray[np.float_], original: ArrayLike) -> ArrayLike:
+    """Return ``value`` as a Python float when ``original`` was scalar."""
+    if np.isscalar(original):
+        return float(value)
+    if isinstance(original, np.ndarray) and value.shape == ():
+        return float(value)
+    return value
+
+
+def softplus(x: ArrayLike) -> ArrayLike:
+    """Numerically stable softplus transform.
+
+    Parameters
+    ----------
+    x:
+        Input scalar or array.
+
+    Returns
+    -------
+    ArrayLike
+        Softplus of the input with the same shape as ``x``.
+    """
+
+    x_arr = np.asarray(x, dtype=float)
+    out = np.log1p(np.exp(-np.abs(x_arr))) + np.maximum(x_arr, 0.0)
+    return _as_native_type(out, x)
+
+
+def inv_softplus(y: ArrayLike) -> ArrayLike:
+    """Inverse of :func:`softplus` on the positive real line."""
+
+    y_arr = np.asarray(y, dtype=float)
+    out = np.log(np.expm1(y_arr))
+    return _as_native_type(out, y)
+
+
+def tanh_constrain(x: ArrayLike) -> ArrayLike:
+    """Map real values to ``(-1, 1)`` via the hyperbolic tangent."""
+
+    x_arr = np.asarray(x, dtype=float)
+    out = np.tanh(x_arr)
+    return _as_native_type(out, x)
+
+
+def artanh_unconstrain(y: ArrayLike) -> ArrayLike:
+    """Inverse of :func:`tanh_constrain` with domain ``(-1, 1)``."""
+
+    y_arr = np.asarray(y, dtype=float)
+    if np.any(np.abs(y_arr) >= 1.0):
+        raise ValueError("Input to artanh_unconstrain must have absolute value < 1.")
+    out = np.arctanh(y_arr)
+    return _as_native_type(out, y)
+
+
+def to_unit_ball(z: Iterable[float]) -> NDArray[np.float_]:
+    """Project unconstrained values to the open unit ball.
+
+    The mapping ``v -> v / (1 + ||v||)`` ensures that the resulting vector
+    has Euclidean norm strictly less than one.  This is convenient for
+    correlation-style parameters that must satisfy
+    ``||rho_bm||^2 + ||rho_bg||^2 < 1``.
+    """
+
+    z_arr = np.asarray(list(z), dtype=float)
+    norm = np.linalg.norm(z_arr)
+    scale = 1.0 / (1.0 + norm)
+    return z_arr * scale
+
+
+def from_unit_ball(v: Iterable[float]) -> NDArray[np.float_]:
+    """Inverse transformation for :func:`to_unit_ball`."""
+
+    v_arr = np.asarray(list(v), dtype=float)
+    norm = np.linalg.norm(v_arr)
+    if norm >= 1.0:
+        raise ValueError("Input to from_unit_ball must lie strictly inside the unit ball.")
+    scale = 1.0 / (1.0 - norm)
+    return v_arr * scale
+
+
+def constrain_params(params: BubbleParamsUnconstrained) -> BubbleParams:
+    """Map unconstrained parameters onto the interpretable constrained space."""
+
+    rho_concat = np.concatenate((params.z_rho_bm, params.z_rho_bg))
+    rho = to_unit_ball(rho_concat)
+    d_m = params.z_rho_bm.shape[0]
+    rho_bm = rho[:d_m]
+    rho_bg = rho[d_m:]
+
+    return BubbleParams(
+        B0=float(softplus(params.z_B0)),
+        mu_b=float(params.z_mu_b),
+        phi_b=float(tanh_constrain(params.z_phi_b)),
+        sigma_h=float(softplus(params.z_sigma_h)),
+        rho_bm=rho_bm,
+        rho_bg=rho_bg,
+    )
+
+
+def unconstrain_params(params: BubbleParams) -> BubbleParamsUnconstrained:
+    """Map constrained parameters back to an unconstrained representation."""
+
+    rho_concat = np.concatenate((params.rho_bm, params.rho_bg))
+    rho_z = from_unit_ball(rho_concat)
+    d_m = params.rho_bm.shape[0]
+    rho_bm_z = rho_z[:d_m]
+    rho_bg_z = rho_z[d_m:]
+
+    return BubbleParamsUnconstrained(
+        z_B0=float(inv_softplus(params.B0)),
+        z_mu_b=float(params.mu_b),
+        z_phi_b=float(artanh_unconstrain(params.phi_b)),
+        z_sigma_h=float(inv_softplus(params.sigma_h)),
+        z_rho_bm=rho_bm_z,
+        z_rho_bg=rho_bg_z,
+    )
+
+
+__all__ = [
+    "softplus",
+    "inv_softplus",
+    "tanh_constrain",
+    "artanh_unconstrain",
+    "to_unit_ball",
+    "from_unit_ball",
+    "constrain_params",
+    "unconstrain_params",
+]

--- a/src/bubble/pmhmc/types.py
+++ b/src/bubble/pmhmc/types.py
@@ -1,0 +1,123 @@
+"""Core type definitions for the bubble particle MCMC module.
+
+The classes defined here capture the observed data, algorithmic
+configuration, model parameters in both constrained and unconstrained
+spaces, and the structure of the returned results.  These are kept
+dataclass-based so that they play nicely with static type checking and
+can be easily serialized in later development stages.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass
+class BubbleData:
+    """Container for the observable inputs required by the bubble model.
+
+    Attributes
+    ----------
+    T:
+        Number of time periods in the panel.
+    y_net_fund:
+        Observed net-fundamental price series :math:`y_t = V_t - p^{d}_t D_t`
+        with shape ``(T,)``.
+    r_t:
+        Short rate series :math:`r_t = g_{1, t}` with shape ``(T,)``.
+    m_t:
+        Factor loadings for the ``m`` block with shape ``(T, d_m)``.
+    g_t:
+        Factor loadings for the ``g`` block with shape ``(T, d_g)``.
+    h_t:
+        Latent volatility states with shape ``(T, d_h)``.
+    Dm_t:
+        Diagonal entries used for the ``m`` block dynamics at each
+        ``t`` with shape ``(T, d_m)``.
+    Dg_t:
+        Diagonal entries used for the ``g`` block dynamics at each
+        ``t`` with shape ``(T, d_g)``.
+    Sigma_m:
+        Lower-triangular matrix with unit diagonal elements describing
+        factor correlations for the ``m`` block, shape ``(d_m, d_m)``.
+    Sigma_g:
+        Lower-triangular Cholesky factor of :math:`\Sigma_g` with
+        shape ``(d_g, d_g)``.
+    Sigma_gm:
+        Cross-block covariance matrix between ``g`` and ``m`` with shape
+        ``(d_g, d_m)``.
+    """
+
+    T: int
+    y_net_fund: NDArray[np.float_]
+    r_t: NDArray[np.float_]
+    m_t: NDArray[np.float_]
+    g_t: NDArray[np.float_]
+    h_t: NDArray[np.float_]
+    Dm_t: NDArray[np.float_]
+    Dg_t: NDArray[np.float_]
+    Sigma_m: NDArray[np.float_]
+    Sigma_g: NDArray[np.float_]
+    Sigma_gm: NDArray[np.float_]
+
+
+@dataclass
+class PMHMCConfig:
+    """Configuration options controlling the PM-HMC sampler."""
+
+    gh_nodes: int
+    N_is: int
+    seed: int
+    hmc_num_warmup: int
+    hmc_num_samples: int
+    hmc_step_size: float
+    hmc_num_steps: int
+    max_tree_depth: int
+    use_truncation: bool
+
+
+@dataclass
+class BubbleParams:
+    """Model parameters in their constrained (interpretable) space."""
+
+    B0: float
+    mu_b: float
+    phi_b: float
+    sigma_h: float
+    rho_bm: NDArray[np.float_]
+    rho_bg: NDArray[np.float_]
+
+
+@dataclass
+class BubbleParamsUnconstrained:
+    """Model parameters expressed on an unconstrained real-valued space."""
+
+    z_B0: float
+    z_mu_b: float
+    z_phi_b: float
+    z_sigma_h: float
+    z_rho_bm: NDArray[np.float_]
+    z_rho_bg: NDArray[np.float_]
+
+
+@dataclass
+class PMHMCResult:
+    """Result bundle returned by future PM-HMC inference routines."""
+
+    params: BubbleParams
+    log_like_hat: float
+    accept_rate: float
+    draws_constrained: Dict[str, NDArray[np.float_]]
+    diagnostics: Dict[str, Any]
+
+
+__all__ = [
+    "BubbleData",
+    "BubbleParams",
+    "BubbleParamsUnconstrained",
+    "PMHMCConfig",
+    "PMHMCResult",
+]


### PR DESCRIPTION
## Summary
- add dataclasses for bubble PM-HMC data, configuration, and parameter containers
- implement constrained/unconstrained parameter transforms and helper utilities
- scaffold simple prior composition helpers and expose the new package API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2c54757608320863e83f77038591e