### PR TITLE
Implement PMHMC parameter transforms

### DIFF
--- a/src/bubble/pmhmc/__init__.py
+++ b/src/bubble/pmhmc/__init__.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 
 from .prior import BubblePrior, gaussian_logpdf, isotropic_gaussian_logpdf
 from .transforms import (
-    artanh_unconstrain,
-    constrain_params,
-    from_unit_ball,
     inv_softplus,
+    renorm_rho,
     softplus,
-    tanh_constrain,
-    to_unit_ball,
-    unconstrain_params,
+    tanh_to_interval,
+    unconstrained_to_constrained,
 )
 from .types import (
     BubbleData,
@@ -27,14 +24,11 @@ __all__ = [
     "BubblePrior",
     "PMHMCConfig",
     "PMHMCResult",
-    "artanh_unconstrain",
-    "constrain_params",
-    "from_unit_ball",
     "gaussian_logpdf",
     "inv_softplus",
     "isotropic_gaussian_logpdf",
+    "renorm_rho",
     "softplus",
-    "tanh_constrain",
-    "to_unit_ball",
-    "unconstrain_params",
+    "tanh_to_interval",
+    "unconstrained_to_constrained",
 ]


### PR DESCRIPTION
## Summary
- add numpy softplus/inv-softplus/tanh interval transforms and rho renormalization with documented Jacobian treatment
- expose a mapping from unconstrained PMHMC parameters to constrained space returning log-Jacobian adjustments
- update package exports to the new transform API

## Testing
- pytest tests/test_shapes.py


------
https://chatgpt.com/codex/tasks/task_e_68d2c768067c8320a524b18e796e0e1a