### PR TITLE
Add artifact registry and CLI wiring for equity pricing outputs

### DIFF
--- a/config/paths.yaml
+++ b/config/paths.yaml
@@ -1,0 +1,2 @@
+artifacts:
+  root: ./artifacts

--- a/scripts/price_equity.py
+++ b/scripts/price_equity.py
@@ -1,0 +1,136 @@
+"""Command-line interface to compute and export equity net-fundamental series."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from equity.price_equity import price_equity_and_export
+from tsm.equity_pricer import EquityPricingInputs
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise TypeError(f"{path} must contain a mapping")
+    return data
+
+
+def _equity_inputs_from_npz(path: Path) -> EquityPricingInputs:
+    data = np.load(path, allow_pickle=True)
+    d_m = int(data["d_m"])
+    d_g = int(data["d_g"])
+    d_h = int(data["d_h"])
+    return EquityPricingInputs(
+        d_m=d_m,
+        d_g=d_g,
+        d_h=d_h,
+        Phi_m=data["Phi_m"],
+        Phi_mg=data["Phi_mg"],
+        Phi_mh=data["Phi_mh"],
+        Phi_h=data["Phi_h"],
+        Phi_g=data["Phi_g"],
+        Phi_g_Q=data["Phi_g_Q"],
+        Phi_gm=data["Phi_gm"],
+        Phi_gh=data["Phi_gh"],
+        Sigma_m=data["Sigma_m"],
+        Sigma_g=data["Sigma_g"],
+        Sigma_g_Q=data["Sigma_g_Q"],
+        Sigma_hm=data["Sigma_hm"],
+        Sigma_hg=data["Sigma_hg"],
+        Sigma_h=data["Sigma_h"],
+        mu_m=data["mu_m"],
+        mu_g=data["mu_g"],
+        mu_g_Q=data["mu_g_Q"],
+        mu_h=data["mu_h"],
+        Gamma0=data["Gamma0"],
+        Gamma1=data["Gamma1"],
+        gamma_dd0=float(data["gamma_dd0"]),
+        gamma_dd2=data["gamma_dd2"],
+        e_div_ix=int(data.get("e_div_ix", d_m - 1)),
+        e1_g_ix=int(data.get("e1_g_ix", 0)),
+        dividend_uses_lagged_h=bool(data.get("dividend_uses_lagged_h", True)),
+    )
+
+
+def _build_equity_inputs(cfg: Mapping[str, Any]) -> EquityPricingInputs:
+    if "npz" in cfg:
+        return _equity_inputs_from_npz(Path(cfg["npz"]))
+    return EquityPricingInputs(**cfg)
+
+
+def _load_states_and_observables(cfg: Mapping[str, Any]) -> tuple[Dict[str, np.ndarray], pd.Series, pd.Series]:
+    if "npz" in cfg:
+        path = Path(cfg["npz"])
+        data = np.load(path, allow_pickle=True)
+        index = pd.to_datetime(data["dates"]) if "dates" in data else pd.RangeIndex(data["m_t"].shape[0], name="time")
+        if not isinstance(index, pd.DatetimeIndex):
+            index = pd.Index(index, name="time")
+        dividends = pd.Series(data["dividend_raw"], index=index, name="dividend_raw")
+        prices = pd.Series(data["spx_price_obs"], index=index, name="price_raw")
+        states = {key: data[key] for key in ("m_t", "g_t", "h_t")}
+        return states, dividends, prices
+    states_path = cfg.get("states_npz")
+    if not states_path:
+        raise ValueError("data config must provide 'npz' or 'states_npz'")
+    state_data = np.load(Path(states_path), allow_pickle=True)
+    index = pd.to_datetime(state_data["dates"]) if "dates" in state_data else pd.RangeIndex(state_data["m_t"].shape[0], name="time")
+    if not isinstance(index, pd.DatetimeIndex):
+        index = pd.Index(index, name="time")
+    states = {key: state_data[key] for key in ("m_t", "g_t", "h_t")}
+
+    if "sp500_price" in cfg and "sp500_dividend" in cfg:
+        from hmc_gibbs.data.io import load_sp500_price_div
+
+        sp500 = load_sp500_price_div(cfg["sp500_price"], cfg["sp500_dividend"])
+        dividends = sp500["dividend_raw"].reindex(index)
+        prices = sp500["price_raw"].reindex(index)
+    else:
+        def _load_series(path_key: str, column: str) -> pd.Series:
+            csv_path = Path(cfg[path_key])
+            df = pd.read_csv(csv_path)
+            if "date" in df.columns:
+                idx = pd.to_datetime(df["date"])
+            else:
+                idx = index
+            value_col = column if column in df.columns else df.columns[-1]
+            return pd.Series(df[value_col].to_numpy(), index=idx, name=column)
+
+        dividends = _load_series("dividends_csv", "dividend_raw")
+        prices = _load_series("prices_csv", "price_raw")
+
+    dividends = dividends.astype(float)
+    prices = prices.astype(float)
+    dividends = dividends.reindex(index)
+    prices = prices.reindex(index)
+    return states, dividends, prices
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True, help="Model configuration YAML file.")
+    parser.add_argument("--data", type=Path, required=True, help="Data configuration YAML file.")
+    args = parser.parse_args()
+
+    model_cfg = _load_yaml(args.config)
+    data_cfg = _load_yaml(args.data)
+
+    theta_cfg = model_cfg.get("equity", model_cfg)
+    data_block = data_cfg.get("equity", data_cfg)
+
+    theta = _build_equity_inputs(theta_cfg)
+    states, dividends, prices = _load_states_and_observables(data_block)
+
+    combined_config: Dict[str, Any] = {"model": model_cfg, "data": data_cfg}
+    run_id = price_equity_and_export(theta, states, dividends, prices, combined_config)
+    print(run_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_bubble_step.py
+++ b/scripts/run_bubble_step.py
@@ -1,0 +1,38 @@
+"""CLI entry point for the bubble PM-HMC stage using stored equity artifacts."""
+
+from __future__ import annotations
+
+import argparse
+
+import pandas as pd
+
+from artifacts.registry import ArtifactRegistry
+from bubble.data_io import get_net_fundamental
+
+
+def _format_series_block(series: pd.Series, label: str) -> str:
+    formatted = series.to_string(max_rows=3)
+    return f"{label}:\n{formatted}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", type=str, default=None, help="Equity artifact run identifier (defaults to latest).")
+    args = parser.parse_args()
+
+    registry = ArtifactRegistry.from_default()
+    resolved_run_id = args.run_id or registry.latest_run_id("equity")
+    if resolved_run_id is None:
+        raise FileNotFoundError("No equity artifacts available; run the pricing step first.")
+
+    series = get_net_fundamental(resolved_run_id)
+
+    print(f"[bubble] using equity run: {resolved_run_id}")
+    print(_format_series_block(series.head(3), "first 3"))
+    print(_format_series_block(series.tail(3), "last 3"))
+    # Placeholder for the actual HMC/PM-HMC execution. Once integrated, invoke the
+    # sampling routine here using ``series`` as the observed net-fundamental prices.
+
+
+if __name__ == "__main__":
+    main()

--- a/src/artifacts/__init__.py
+++ b/src/artifacts/__init__.py
@@ -1,0 +1,5 @@
+"""Artifact management utilities."""
+
+from .registry import ArtifactRegistry, new_run_id
+
+__all__ = ["ArtifactRegistry", "new_run_id"]

--- a/src/artifacts/registry.py
+++ b/src/artifacts/registry.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG_PATH = PROJECT_ROOT / "config" / "paths.yaml"
+DEFAULT_ARTIFACT_DIRNAME = "artifacts"
+
+
+def _read_paths_config(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise TypeError("paths.yaml must contain a mapping")
+    return data
+
+
+def _resolve_artifacts_root() -> Path:
+    cfg = _read_paths_config(DEFAULT_CONFIG_PATH)
+    root_value = cfg.get("artifacts", {}).get("root") if isinstance(cfg.get("artifacts"), dict) else None
+    if root_value:
+        root_path = Path(root_value)
+        if not root_path.is_absolute():
+            root_path = PROJECT_ROOT / root_path
+    else:
+        root_path = PROJECT_ROOT / DEFAULT_ARTIFACT_DIRNAME
+    root_path.mkdir(parents=True, exist_ok=True)
+    return root_path
+
+
+def _short_git_rev() -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    short = result.stdout.strip()
+    return short or None
+
+
+def _is_git_dirty() -> Optional[bool]:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return bool(result.stdout.strip())
+
+
+def new_run_id(prefix: str) -> str:
+    """Return a timestamped identifier using the Git short hash when available."""
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    suffix = _short_git_rev()
+    if not suffix:
+        suffix = secrets.token_hex(4)
+    return f"{prefix}-{timestamp}-{suffix}"
+
+
+class ArtifactRegistry:
+    """File-system backed registry for pipeline artifacts."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root).expanduser().resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_default(cls) -> "ArtifactRegistry":
+        """Build a registry using ``config/paths.yaml`` or the default location."""
+
+        return cls(_resolve_artifacts_root())
+
+    # --- directory helpers -------------------------------------------------
+    def _kind_dir(self, kind: str) -> Path:
+        path = self.root / kind
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _run_dir(self, kind: str, run_id: str) -> Path:
+        path = self._kind_dir(kind) / run_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def equity_dir(self, run_id: str) -> Path:
+        """Return the directory for an equity run, creating it if necessary."""
+
+        return self._run_dir("equity", run_id)
+
+    def net_fundamental_path(self, run_id: str) -> Path:
+        """Return the Parquet path storing the net-fundamental series."""
+
+        return self.equity_dir(run_id) / "net_fundamental.parquet"
+
+    def manifest_path(self, run_id: str, kind: str = "equity") -> Path:
+        """Return the manifest path for the given run identifier."""
+
+        return self._run_dir(kind, run_id) / "manifest.json"
+
+    # --- manifest utilities ------------------------------------------------
+    def write_manifest(self, run_id: str, payload: Dict[str, Any], kind: str = "equity") -> Path:
+        """Persist ``payload`` to ``manifest.json`` and update the ``_latest`` marker."""
+
+        manifest_path = self.manifest_path(run_id, kind)
+        self._atomic_write_json(manifest_path, payload)
+        self._write_latest(kind, run_id)
+        return manifest_path
+
+    def load_manifest(self, run_id: str, kind: str = "equity") -> Dict[str, Any]:
+        """Load the JSON manifest for ``run_id``."""
+
+        manifest_path = self.manifest_path(run_id, kind)
+        with manifest_path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def latest_run_id(self, kind: str = "equity") -> Optional[str]:
+        """Return the most recent run identifier for ``kind`` if available."""
+
+        latest_path = self._kind_dir(kind) / "_latest"
+        if latest_path.is_symlink():
+            target = latest_path.resolve()
+            return target.name
+        if latest_path.exists():
+            content = latest_path.read_text(encoding="utf-8").strip()
+            return content or None
+        return None
+
+    # --- low-level filesystem helpers -------------------------------------
+    @staticmethod
+    def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = json.dumps(payload, indent=2, sort_keys=True)
+        ArtifactRegistry._atomic_write_text(path, data)
+
+    @staticmethod
+    def _atomic_write_text(path: Path, text: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile("w", dir=str(path.parent), delete=False, encoding="utf-8") as tmp:
+            tmp.write(text)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_path = Path(tmp.name)
+        tmp_path.replace(path)
+
+    def _write_latest(self, kind: str, run_id: str) -> None:
+        latest_path = self._kind_dir(kind) / "_latest"
+        # Prefer text marker for portability.
+        self._atomic_write_text(latest_path, f"{run_id}\n")
+
+
+__all__ = ["ArtifactRegistry", "new_run_id", "_is_git_dirty"]

--- a/src/bubble/data_io.py
+++ b/src/bubble/data_io.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+from artifacts.registry import ArtifactRegistry
+from equity.pricing_io import load_net_fundamental
+
+
+def get_net_fundamental(run_id: Optional[str] = None) -> pd.Series:
+    """Load the net-fundamental price series for the bubble module."""
+
+    registry = ArtifactRegistry.from_default()
+    resolved_run_id = run_id or registry.latest_run_id("equity")
+    if resolved_run_id is None:
+        raise FileNotFoundError("No equity runs found. Generate an equity pricing artifact first.")
+    return load_net_fundamental(resolved_run_id, registry=registry)
+
+
+__all__ = ["get_net_fundamental"]

--- a/src/equity/__init__.py
+++ b/src/equity/__init__.py
@@ -1,0 +1,1 @@
+"""Equity pricing pipeline utilities."""

--- a/src/equity/price_equity.py
+++ b/src/equity/price_equity.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Optional
+
+import numpy as np
+import pandas as pd
+
+from artifacts.registry import ArtifactRegistry, new_run_id
+from equity.pricing_io import save_net_fundamental
+from tsm.equity_pricer import EquityPricingInputs, price_equity_ratio
+
+
+def _git_commit() -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    commit = result.stdout.strip()
+    return commit or None
+
+
+def _git_dirty() -> Optional[bool]:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return bool(result.stdout.strip())
+
+
+def _normalize(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {str(k): _normalize(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_normalize(v) for v in obj]
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, pd.Series):
+        return _normalize(obj.to_dict())
+    if isinstance(obj, pd.Index):
+        return _normalize(list(obj))
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (np.integer, np.floating)):
+        return obj.item()
+    if hasattr(obj, "__dict__") and not isinstance(obj, type):
+        return _normalize(vars(obj))
+    return obj
+
+
+def _config_hash(config: Any) -> str:
+    normalized = _normalize(config)
+    serialized = json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _theta_summary(theta: EquityPricingInputs) -> MutableMapping[str, Any]:
+    gamma_dd2 = np.asarray(theta.gamma_dd2, dtype=float)
+    return {
+        "d_m": int(theta.d_m),
+        "d_g": int(theta.d_g),
+        "d_h": int(theta.d_h),
+        "gamma_dd0": float(theta.gamma_dd0),
+        "gamma_dd2_mean": float(gamma_dd2.mean()),
+        "gamma_dd2_std": float(gamma_dd2.std()),
+    }
+
+
+def _ensure_series(obj: Any, name: str) -> pd.Series:
+    if isinstance(obj, pd.Series):
+        series = obj.copy()
+    else:
+        series = pd.Series(obj, name=name)
+    if series.name is None:
+        series.name = name
+    return series
+
+
+def price_equity_and_export(
+    theta: EquityPricingInputs,
+    states: Mapping[str, Any],
+    dividends: Any,
+    prices: Any,
+    config: Mapping[str, Any],
+) -> str:
+    """Compute and persist the net-fundamental equity series.
+
+    Parameters
+    ----------
+    theta:
+        Equity pricing inputs controlling the ATSM recursion.
+    states:
+        Mapping containing ``m_t``, ``g_t``, and ``h_t`` state arrays with shapes
+        ``(T, d_m)``, ``(T, d_g)``, and ``(T, d_h)`` respectively.
+    dividends, prices:
+        Observed monthly dividend and price series already scaled by dividing by
+        ``1200`` per the pipeline convention. Accepts array-like inputs which
+        are converted to :class:`pandas.Series`.
+    config:
+        Configuration dictionary whose hash is recorded in the manifest for
+        reproducibility.
+
+    Returns
+    -------
+    str
+        Run identifier registered in the artifact registry.
+    """
+
+    m_t = np.asarray(states["m_t"], dtype=float)
+    g_t = np.asarray(states["g_t"], dtype=float)
+    h_t = np.asarray(states["h_t"], dtype=float)
+
+    ratio = price_equity_ratio(theta, m_t=m_t, g_t=g_t, h_t=h_t)
+
+    dividend_series = _ensure_series(dividends, "dividend_raw")
+    price_series = _ensure_series(prices, "price_raw")
+
+    if len(dividend_series) != ratio.shape[0] or len(price_series) != ratio.shape[0]:
+        raise ValueError("State and observable series must share the same length.")
+    if not dividend_series.index.equals(price_series.index):
+        raise ValueError("Dividend and price series must be aligned on the same index.")
+
+    ratio_series = pd.Series(ratio, index=dividend_series.index, name="ratio")
+    fundamental = ratio_series * dividend_series
+    net_fundamental = price_series - fundamental
+    net_fundamental.name = "net_fundamental"
+
+    registry = ArtifactRegistry.from_default()
+    run_id = new_run_id("equity")
+    save_net_fundamental(run_id, net_fundamental, registry=registry)
+
+    git_commit = _git_commit() or "unknown"
+    git_dirty = _git_dirty()
+    manifest = {
+        "run_id": run_id,
+        "T": int(len(net_fundamental)),
+        "start": str(net_fundamental.index[0]),
+        "end": str(net_fundamental.index[-1]),
+        "generated_by": "price_equity_and_export",
+        "git": {"commit": git_commit, "dirty": bool(git_dirty) if git_dirty is not None else False},
+        "config_hash": _config_hash(config),
+        "theta_summary": dict(_theta_summary(theta)),
+    }
+    registry.write_manifest(run_id, manifest)
+    return run_id
+
+
+__all__ = ["price_equity_and_export"]

--- a/src/equity/pricing_io.py
+++ b/src/equity/pricing_io.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from artifacts.registry import ArtifactRegistry
+
+SERIES_NAME = "net_fundamental"
+TIME_COLUMN = "time"
+
+
+def _ensure_series(ts: pd.Series) -> pd.Series:
+    if isinstance(ts, pd.Series):
+        return ts.copy()
+    return pd.Series(ts)
+
+
+def _validate_index(index: pd.Index) -> None:
+    if isinstance(index, pd.DatetimeIndex):
+        return
+    if pd.api.types.is_integer_dtype(index):
+        return
+    raise TypeError("net-fundamental series must use a DatetimeIndex or integer index")
+
+
+def save_net_fundamental(
+    run_id: str,
+    ts: pd.Series,
+    *,
+    registry: ArtifactRegistry,
+) -> Path:
+    """Persist the net-fundamental series to Parquet.
+
+    Parameters
+    ----------
+    run_id:
+        Identifier returned by :func:`artifacts.registry.new_run_id`.
+    ts:
+        Net-fundamental price series. Values should be expressed in monthly
+        percentage units divided by ``1200`` in accordance with the pipeline
+        conventions.
+    registry:
+        Artifact registry controlling output locations.
+    """
+
+    series = _ensure_series(ts)
+    _validate_index(series.index)
+    series = series.astype(float)
+    series.name = SERIES_NAME
+
+    series.index = pd.Index(series.index, name=TIME_COLUMN)
+    df = series.to_frame().reset_index()
+
+    path = registry.net_fundamental_path(run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", dir=str(path.parent), delete=False) as tmp:
+        temp_path = Path(tmp.name)
+    df.to_parquet(temp_path, engine="pyarrow", index=False)
+    temp_path.replace(path)
+    return path
+
+
+def load_net_fundamental(
+    run_id: Optional[str] = None,
+    *,
+    registry: Optional[ArtifactRegistry] = None,
+) -> pd.Series:
+    """Load a previously exported net-fundamental series.
+
+    Parameters
+    ----------
+    run_id:
+        Optional identifier. When omitted the registry ``_latest`` pointer is
+        used.
+    registry:
+        Registry instance. Defaults to :meth:`ArtifactRegistry.from_default`.
+
+    Returns
+    -------
+    pandas.Series
+        Series indexed by ``DatetimeIndex`` or ``Index`` of integers with values
+        in monthly percentage units divided by ``1200``.
+    """
+
+    reg = registry or ArtifactRegistry.from_default()
+    resolved_run_id = run_id or reg.latest_run_id("equity")
+    if resolved_run_id is None:
+        raise FileNotFoundError("No equity runs found in the artifact registry.")
+
+    path = reg.net_fundamental_path(resolved_run_id)
+    if not path.exists():
+        raise FileNotFoundError(f"net_fundamental.parquet not found for run {resolved_run_id}")
+
+    df = pd.read_parquet(path, engine="pyarrow")
+    if TIME_COLUMN not in df.columns or SERIES_NAME not in df.columns:
+        raise ValueError("Parquet file missing required columns 'time'/'net_fundamental'.")
+
+    time_col = df[TIME_COLUMN]
+    if pd.api.types.is_datetime64_any_dtype(time_col):
+        dt_index = pd.DatetimeIndex(pd.to_datetime(time_col), name=TIME_COLUMN)
+        inferred = pd.infer_freq(dt_index)
+        if inferred:
+            dt_index = pd.DatetimeIndex(dt_index, name=TIME_COLUMN, freq=inferred)
+        index = dt_index
+    elif pd.api.types.is_integer_dtype(time_col):
+        index = pd.Index(time_col.astype(int), name=TIME_COLUMN)
+    else:
+        raise TypeError("Stored time column must be datetime64 or integer typed.")
+
+    series = pd.Series(df[SERIES_NAME].astype(float).to_numpy(), index=index, name=SERIES_NAME)
+    return series
+
+
+__all__ = ["load_net_fundamental", "save_net_fundamental"]

--- a/tests/test_artifacts_equity.py
+++ b/tests/test_artifacts_equity.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+
+from artifacts.registry import ArtifactRegistry, new_run_id
+from equity.pricing_io import load_net_fundamental, save_net_fundamental
+
+
+def test_net_fundamental_round_trip(tmp_path) -> None:
+    registry = ArtifactRegistry(tmp_path / "artifacts")
+    run_id = new_run_id("equity")
+
+    index = pd.date_range("2000-01-31", periods=5, freq="ME", name="time")
+    values = pd.Series(np.linspace(0.0, 1.0, len(index)), index=index, name="net_fundamental")
+
+    parquet_path = save_net_fundamental(run_id, values, registry=registry)
+    assert parquet_path.exists()
+
+    manifest_payload = {"run_id": run_id, "note": "roundtrip"}
+    manifest_path = registry.write_manifest(run_id, manifest_payload)
+    assert manifest_path.exists()
+
+    loaded = load_net_fundamental(run_id, registry=registry)
+    pd.testing.assert_series_equal(loaded, values)
+
+    latest = registry.latest_run_id("equity")
+    assert latest == run_id
+
+    manifest_loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest_loaded["run_id"] == run_id
+
+    latest_marker = registry.root / "equity" / "_latest"
+    assert latest_marker.read_text(encoding="utf-8").strip() == run_id


### PR DESCRIPTION
## Summary
- add an artifact registry backed by config/paths.yaml with utilities for equity runs
- implement net-fundamental save/load helpers plus a pricing export entry point and CLIs
- expose the bubble data loader and cover the round-trip path with a pytest

## Testing
- pytest tests/test_artifacts_equity.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c91fa14c832087f0648cbacf25fd