### PR TITLE
Add MCMC sweep orchestration driver and utilities

### DIFF
--- a/config/sweep.yaml
+++ b/config/sweep.yaml
@@ -1,0 +1,26 @@
+mcmc:
+  burn_in: 500
+  iters: 2000
+  thin: 1
+  checkpoint_every: 25
+  flush_every: 25
+  seed: 12345
+  platform: "cpu"   # "cpu" | "gpu" (JAX platform)
+  run_prefix: "mcmc"
+
+particle_filter:
+  n_particles: 300
+  pg_as: true
+  ancestor_resampling: true
+
+data:
+  # paths used by loaders
+  m_pool_mat: "data/m_pool.mat"
+  m_pool_var: "m_pool"       # variable name in the .mat file
+  dividends_csv: "data/sp500_div_growth.csv"
+  yields_csv: "data/yields_3_6_12_36_60_84_120.csv"
+  price_csv: "data/sp500_price.csv"
+  raw_div_csv: "data/sp500_raw_div.csv"
+
+paths:
+  artifacts_root: "./artifacts"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+arviz>=0.16
+rich>=13
+typer>=0.12
+pyyaml>=6
+pandas>=2
+pyarrow>=15
+numpy>=1.26
+scipy>=1.11
+tqdm>=4.66
+jax>=0.4
+blackjax>=1.1
+numba>=0.59

--- a/scripts/one_click_mcmc.bat
+++ b/scripts/one_click_mcmc.bat
@@ -1,0 +1,3 @@
+@echo off
+REM One-button launcher with defaults
+python -m scripts.run_mcmc --config config\sweep.yaml %*

--- a/scripts/one_click_mcmc.sh
+++ b/scripts/one_click_mcmc.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python -m scripts.run_mcmc --config config/sweep.yaml "$@"

--- a/scripts/run_mcmc.py
+++ b/scripts/run_mcmc.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import typer
+
+from driver.sweep import run_sweep
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def main(
+    config: str = typer.Option("config/sweep.yaml", help="Path to sweep config"),
+    resume: bool = typer.Option(False, help="Resume from latest checkpoint in run dir"),
+) -> None:
+    run_sweep(config_path=config, resume=resume)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/artifacts/registry.py
+++ b/src/artifacts/registry.py
@@ -85,9 +85,14 @@ class ArtifactRegistry:
         self.root.mkdir(parents=True, exist_ok=True)
 
     @classmethod
-    def from_default(cls) -> "ArtifactRegistry":
-        """Build a registry using ``config/paths.yaml`` or the default location."""
+    def from_default(cls, root: Optional[str | os.PathLike[str]] = None) -> "ArtifactRegistry":
+        """Build a registry using ``config/paths.yaml`` or the provided location."""
 
+        if root is not None:
+            root_path = Path(root)
+            if not root_path.is_absolute():
+                root_path = PROJECT_ROOT / root_path
+            return cls(root_path)
         return cls(_resolve_artifacts_root())
 
     # --- directory helpers -------------------------------------------------

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,3 @@
+"""Data loading helpers for MCMC sweeps."""
+
+__all__ = ["load_observed_inputs", "sample_m"]

--- a/src/data/random_m_loader.py
+++ b/src/data/random_m_loader.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import pandas as pd
+from scipy.io import loadmat
+
+
+def _require_file(p: str | Path) -> Path:
+    p = Path(p)
+    if not p.exists():
+        raise FileNotFoundError(f"Required file not found: {p}")
+    return p
+
+
+def load_observed_inputs(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Load yields, dividends, raw price/dividend as pandas objects."""
+
+    dpaths = cfg["data"]
+    divg = pd.read_csv(_require_file(dpaths["dividends_csv"]))
+    yields = pd.read_csv(_require_file(dpaths["yields_csv"]))
+    price = pd.read_csv(_require_file(dpaths["price_csv"]))
+    raw_div = pd.read_csv(_require_file(dpaths["raw_div_csv"]))
+    return {"div_growth": divg, "yields": yields, "price": price, "raw_div": raw_div}
+
+
+def sample_m(cfg: Dict[str, Any], rng: np.random.Generator) -> Tuple[np.ndarray, int]:
+    """
+    Draw a random matrix m from a pre-generated MAT pool.
+    Expects a 3D array (Nm x T x Npool) or list-of-matrices in `m_pool`.
+    Returns (m, index).
+    """
+
+    f = _require_file(cfg["data"]["m_pool_mat"])
+    var = cfg["data"]["m_pool_var"]
+    mat = loadmat(f)
+    if var not in mat:
+        raise KeyError(f"Variable '{var}' not in {f}")
+    pool = mat[var]
+    # Accept: (Nm, T, K) or object array of (Nm,T)
+    if pool.ndim == 3:
+        k = pool.shape[2]
+        idx = rng.integers(0, k)
+        m = np.asarray(pool[:, :, idx], dtype=float)
+    elif pool.dtype == object:
+        k = pool.size
+        idx = rng.integers(0, k)
+        m = np.asarray(pool[0, idx], dtype=float)
+    else:
+        raise ValueError(f"Unsupported shape for m_pool: {pool.shape} d={pool.ndim}")
+    return m, int(idx)

--- a/src/driver/__init__.py
+++ b/src/driver/__init__.py
@@ -1,0 +1,5 @@
+"""Driver utilities for orchestrating MCMC sweeps."""
+
+from .sweep import run_sweep
+
+__all__ = ["run_sweep"]

--- a/src/driver/sweep.py
+++ b/src/driver/sweep.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import arviz as az
+import numpy as np
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from artifacts.registry import ArtifactRegistry, new_run_id
+from data.random_m_loader import load_observed_inputs, sample_m
+from utils.checkpoint import Checkpoint, load_latest_checkpoint, save_checkpoint
+from utils.diagnostics import TraceAccumulator, compute_ess_per_sec
+
+from .typing import DrawDict
+
+console = Console()
+
+
+# --------- Optional dynamic imports with graceful fallback stubs ----------
+def _safe_import(name: str, attr: str, stub):
+    try:
+        mod = importlib.import_module(name)
+        fn = getattr(mod, attr)
+        return fn
+    except Exception:  # pragma: no cover - fallback path only
+        return stub
+
+
+def _stub_run_bond_step(*args, **kwargs):  # pragma: no cover - fallback stub
+    raise NotImplementedError(
+        "run_bond_posterior_step not found. Create `bond/pipeline.py` with:\n"
+        "def run_bond_posterior_step(m, observed, cfg, rng_key, resume_state=None)->(theta, states, aux, diag): ..."
+    )
+
+
+def _stub_price_equity(*args, **kwargs):  # pragma: no cover - fallback stub
+    raise NotImplementedError(
+        "price_equity_and_export not found. Create `equity/price_equity.py` with:\n"
+        "def price_equity_and_export(theta, states, dividends, prices, cfg)->str: ... (returns equity run_id)"
+    )
+
+
+def _stub_run_bubble_step(*args, **kwargs):  # pragma: no cover - fallback stub
+    raise NotImplementedError(
+        "run_bubble_step not found. Create `bubble/pipeline.py` with:\n"
+        "def run_bubble_step(net_fund_series, cfg, rng_key, resume_state=None)->(theta_b, latents_b, diag_b): ..."
+    )
+
+
+run_bond_posterior_step = _safe_import(
+    "bond.pipeline", "run_bond_posterior_step", _stub_run_bond_step
+)
+price_equity_and_export = _safe_import(
+    "equity.price_equity", "price_equity_and_export", _stub_price_equity
+)
+run_bubble_step = _safe_import(
+    "bubble.pipeline", "run_bubble_step", _stub_run_bubble_step
+)
+
+
+# --------- typing helpers ----------
+@dataclass
+class SweepState:
+    iter0: int
+    total: int
+    burn_in: int
+    thin: int
+    numpy_rng: np.random.Generator
+    jax_seed: int
+    run_id: str
+
+
+def _set_jax_platform(platform: str) -> None:
+    if platform:
+        os.environ["JAX_PLATFORM_NAME"] = platform
+    # good hygiene for GPUs
+    os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+
+
+def _load_cfg(path: str | Path) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _init_run(
+    cfg: Dict[str, Any]
+) -> Tuple[ArtifactRegistry, SweepState, Path, Path]:
+    reg = ArtifactRegistry.from_default(cfg.get("paths", {}).get("artifacts_root"))
+    run_id = new_run_id(prefix=cfg["mcmc"].get("run_prefix", "mcmc"))
+    mcmc_dir = reg.root / "mcmc" / run_id
+    checkpoints_dir = mcmc_dir / "checkpoints"
+    checkpoints_dir.mkdir(parents=True, exist_ok=True)
+    (mcmc_dir / "diagnostics").mkdir(parents=True, exist_ok=True)
+    (mcmc_dir / "traces").mkdir(parents=True, exist_ok=True)
+    # seeds
+    seed = int(cfg["mcmc"]["seed"])
+    np_rng = np.random.default_rng(seed)
+    jax_seed = seed + 1
+    st = SweepState(
+        iter0=0,
+        total=int(cfg["mcmc"]["iters"]),
+        burn_in=int(cfg["mcmc"]["burn_in"]),
+        thin=int(cfg["mcmc"]["thin"]),
+        numpy_rng=np_rng,
+        jax_seed=jax_seed,
+        run_id=run_id,
+    )
+    reg.write_manifest(run_id, {"kind": "mcmc", "config": cfg}, kind="mcmc")
+    return reg, st, mcmc_dir, checkpoints_dir
+
+
+def _resume_if_any(cp_dir: Path, st: SweepState) -> Tuple[int, Optional[Checkpoint]]:
+    cp = load_latest_checkpoint(cp_dir)
+    if cp is None:
+        return 0, None
+    console.print(f"[yellow]Resuming from checkpoint at iteration {cp.iter}[/yellow]")
+    return cp.iter + 1, cp
+
+
+def _ensure_dict(obj: Any) -> Dict[str, Any]:
+    if isinstance(obj, dict):
+        return obj
+    return {}
+
+
+def sweep_once(
+    cfg: Dict[str, Any],
+    reg: ArtifactRegistry,
+    st: SweepState,
+    mcmc_dir: Path,
+    iter_idx: int,
+    observed: Dict[str, Any],
+    trace: TraceAccumulator,
+    prev_cp: Optional[Checkpoint],
+) -> Checkpoint:
+    t_iter0 = time.perf_counter()
+    # 1) draw m
+    m, m_idx = sample_m(cfg, st.numpy_rng)
+    # 2) bond step
+    theta_bond, states_bond, aux_bond, diag_bond = run_bond_posterior_step(
+        m=m,
+        observed=observed,
+        cfg=cfg,
+        rng_key=st.jax_seed + iter_idx,  # simple per-iter seed shift
+        resume_state=None if prev_cp is None else prev_cp.bond_state,
+    )
+    # 3) equity pricing
+    run_id_equity = price_equity_and_export(
+        theta=theta_bond,
+        states=states_bond,
+        dividends=observed["div_growth"],
+        prices=observed["price"],
+        cfg=cfg,
+    )
+    # 4) bubble step
+    try:
+        from equity.pricing_io import load_net_fundamental
+
+        net_fund = load_net_fundamental(run_id_equity, registry=reg)
+    except Exception as exc:  # pragma: no cover - runtime error path
+        raise RuntimeError(
+            "Cannot locate net_fundamental output from equity step."
+        ) from exc
+
+    theta_bub, _, diag_bub = run_bubble_step(
+        net_fund_series=net_fund,
+        cfg=cfg,
+        rng_key=st.jax_seed + 10_000 + iter_idx,
+        resume_state=None if prev_cp is None else prev_cp.bubble_state,
+    )
+
+    # Collect minimal draws for diagnostics (add keys as needed)
+    draws: DrawDict = {
+        # examples — extend with your hardest parameters:
+        "phi_gQ_eigs": np.asarray(_ensure_dict(theta_bond).get("phi_gQ_eigs", [])),
+        "risk_prices": np.asarray(_ensure_dict(theta_bond).get("risk_prices", [])),
+        "sigma_h": np.asarray(_ensure_dict(theta_bub).get("sigma_h", np.nan)),
+        "phi_b": np.asarray(_ensure_dict(theta_bub).get("phi_b", np.nan)),
+    }
+    trace.add_draws(draws)
+
+    # Build checkpoint
+    elapsed = time.perf_counter() - t_iter0
+    bond_aux = _ensure_dict(aux_bond)
+    bubble_diag = _ensure_dict(diag_bub)
+    cp = Checkpoint(
+        iter=iter_idx,
+        burn_in=st.burn_in,
+        thin=st.thin,
+        rng_state_numpy=st.numpy_rng.bit_generator.state,
+        jax_seed=st.jax_seed,
+        elapsed_sec=elapsed,
+        bond_state=bond_aux.get("resume_state"),
+        equity_run_id=run_id_equity,
+        bubble_state=bubble_diag.get("resume_state"),
+        diagnostics={
+            "bond": diag_bond,
+            "bubble": diag_bub,
+            "m_index": m_idx,
+        },
+    )
+    return cp
+
+
+def _export_diagnostics(
+    trace: TraceAccumulator,
+    burn_in: int,
+    thin: int,
+    target_dir: Path,
+) -> None:
+    idata = trace.to_inferencedata(burn_in=burn_in, thin=thin)
+    has_posterior = False
+    if hasattr(idata, "posterior"):
+        try:
+            has_posterior = bool(idata.posterior.data_vars)
+        except AttributeError:
+            has_posterior = False
+    if not has_posterior:
+        return
+    target_dir.mkdir(parents=True, exist_ok=True)
+    trace_path = target_dir.parent / "traces" / "trace.nc"
+    trace_path.parent.mkdir(parents=True, exist_ok=True)
+    idata.to_netcdf(trace_path, mode="w")
+    essps = compute_ess_per_sec(idata, trace.walltimes)
+    df = az.summary(idata, var_names=list(idata.posterior.data_vars))
+    df.to_csv(target_dir / "summary.csv")
+    with open(target_dir / "ess_per_sec.json", "w", encoding="utf-8") as f:
+        json.dump(essps, f, indent=2)
+
+
+def run_sweep(config_path: str, resume: bool = False) -> None:
+    cfg = _load_cfg(config_path)
+    _set_jax_platform(cfg["mcmc"].get("platform", "cpu"))
+    reg, st, mcmc_dir, cp_dir = _init_run(cfg)
+    # Save a copy of config
+    with open(mcmc_dir / "config_snapshot.yaml", "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f)
+
+    observed = load_observed_inputs(cfg)
+    start_iter = 0
+    prev_cp: Optional[Checkpoint] = None
+    if resume:
+        start_iter, prev_cp = _resume_if_any(cp_dir, st)
+
+    trace = TraceAccumulator()
+    burn_in = st.burn_in
+    chkevery = int(cfg["mcmc"]["checkpoint_every"])
+    flushevery = int(cfg["mcmc"]["flush_every"])
+
+    for it in range(start_iter, st.total):
+        cp = sweep_once(cfg, reg, st, mcmc_dir, it, observed, trace, prev_cp)
+        # checkpointing
+        if (it + 1) % chkevery == 0 or it == st.total - 1:
+            save_checkpoint(cp_dir, cp)
+        # flush diagnostics
+        if (it + 1) % flushevery == 0 or it == st.total - 1:
+            _export_diagnostics(trace, burn_in=burn_in, thin=st.thin, target_dir=mcmc_dir / "diagnostics")
+        prev_cp = cp
+
+    # pretty print last summary to console
+    idata = trace.to_inferencedata(burn_in=burn_in, thin=st.thin)
+    has_posterior = False
+    if hasattr(idata, "posterior"):
+        try:
+            has_posterior = bool(idata.posterior.data_vars)
+        except AttributeError:
+            has_posterior = False
+    if has_posterior:
+        df = az.summary(idata)
+        table = Table(title="Posterior diagnostics")
+        table.add_column("param")
+        for col in df.columns:
+            table.add_column(col)
+        for idx, row in df.iterrows():
+            table.add_row(str(idx), *[f"{v:.3g}" for v in row.values])
+        console.print(table)

--- a/src/driver/typing.py
+++ b/src/driver/typing.py
@@ -1,0 +1,5 @@
+from typing import Any, Dict
+
+DrawDict = Dict[str, Any]
+
+__all__ = ["DrawDict"]

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import pickle
+import shutil
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class Checkpoint:
+    iter: int
+    burn_in: int
+    thin: int
+    rng_state_numpy: Dict[str, Any]
+    jax_seed: int
+    elapsed_sec: float
+    # block states are user-defined opaque blobs
+    bond_state: Optional[Dict[str, Any]] = None
+    equity_run_id: Optional[str] = None
+    bubble_state: Optional[Dict[str, Any]] = None
+    diagnostics: Optional[Dict[str, Any]] = None
+
+
+def atomic_write_bytes(target: Path, blob: bytes) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + f".tmp-{int(time.time() * 1000)}")
+    with open(tmp, "wb") as f:
+        f.write(blob)
+    shutil.move(str(tmp), str(target))
+
+
+def save_checkpoint(cp_dir: Path, cp: Checkpoint, tag: Optional[str] = None) -> Path:
+    name = f"iter_{cp.iter:07d}"
+    if tag:
+        name += f"_{tag}"
+    target = cp_dir / f"{name}.pkl"
+    payload = pickle.dumps(cp, protocol=pickle.HIGHEST_PROTOCOL)
+    atomic_write_bytes(target, payload)
+    meta = cp_dir / f"{name}.json"
+    atomic_write_bytes(meta, json.dumps(asdict(cp), default=str).encode("utf-8"))
+    latest = cp_dir / "_latest.txt"
+    atomic_write_bytes(latest, f"{target.name}\n".encode("utf-8"))
+    return target
+
+
+def load_latest_checkpoint(cp_dir: Path) -> Optional[Checkpoint]:
+    latest = cp_dir / "_latest.txt"
+    if not latest.exists():
+        return None
+    fname = cp_dir / latest.read_text().strip()
+    if not fname.exists():
+        return None
+    with open(fname, "rb") as f:
+        return pickle.load(f)

--- a/src/utils/diagnostics.py
+++ b/src/utils/diagnostics.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import time
+from typing import Dict, List
+
+import arviz as az
+import numpy as np
+import pandas as pd
+
+
+class TraceAccumulator:
+    """
+    Minimal accumulator to store per-iteration parameter draws and compute ESS/R-hat.
+    Assumes single-chain, can be extended to multi-chain later.
+    """
+
+    def __init__(self) -> None:
+        self.buffer: Dict[str, List[np.ndarray]] = {}
+        self.walltimes: List[float] = []
+        self._t0 = time.perf_counter()
+
+    def add_draws(self, draw_dict: Dict[str, np.ndarray]) -> None:
+        for k, v in draw_dict.items():
+            v = np.atleast_1d(np.asarray(v))
+            self.buffer.setdefault(k, []).append(v)
+        self.walltimes.append(time.perf_counter() - self._t0)
+
+    def to_inferencedata(self, burn_in: int = 0, thin: int = 1) -> az.InferenceData:
+        post: Dict[str, np.ndarray] = {}
+        for k, seq in self.buffer.items():
+            if not seq:
+                continue
+            arr = np.stack(seq, axis=0)
+            if burn_in > 0:
+                arr = arr[burn_in:, ...]
+            if thin > 1:
+                arr = arr[::thin, ...]
+            if arr.size == 0:
+                continue
+            arr = arr[np.newaxis, ...]  # (chain=1, draw, ...)
+            post[k] = arr
+        return az.from_dict(posterior=post) if post else az.InferenceData()
+
+    def summarize(self, idata: az.InferenceData) -> pd.DataFrame:
+        if not hasattr(idata, "posterior"):
+            return pd.DataFrame()
+        try:
+            var_names = list(idata.posterior.data_vars)
+        except AttributeError:
+            return pd.DataFrame()
+        if not var_names:
+            return pd.DataFrame()
+        summ = az.summary(
+            idata,
+            var_names=var_names,
+            kind="stats",
+            stat_focus="median",
+            round_to=None,
+        )
+        return summ
+
+
+def compute_ess_per_sec(idata: az.InferenceData, walltimes: List[float]) -> Dict[str, float]:
+    """Rough ESS/sec using last timestamp as total time."""
+
+    if not hasattr(idata, "posterior") or not walltimes:
+        return {}
+    try:
+        data_vars = list(idata.posterior.data_vars)
+    except AttributeError:
+        return {}
+    if not data_vars:
+        return {}
+    total_sec = walltimes[-1]
+    ess = az.ess(idata, method="bulk")
+    out: Dict[str, float] = {}
+    for v in ess.data_vars:  # type: ignore[union-attr]
+        val = float(np.asarray(ess[v]).reshape(-1).mean())
+        out[str(v)] = val / max(total_sec, 1e-9)
+    return out


### PR DESCRIPTION
## Summary
- add a Typer-based CLI plus helper scripts to run the end-to-end MCMC sweep
- implement sweep orchestration with checkpointing, diagnostics, and sampling utilities
- introduce configuration/defaults and extend the artifact registry to accept explicit roots

## Testing
- pytest *(fails: AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.)*

------
https://chatgpt.com/codex/tasks/task_e_68d2dad947908320aba920c3a1a82eb6