### PR TITLE
Implement bond sweep engine and HMC utilities

### DIFF
--- a/src/bubble/pmhmc/prior.py
+++ b/src/bubble/pmhmc/prior.py
@@ -25,14 +25,14 @@ SIGMA_H_HALF_NORMAL_SCALE = 1.0
 RHO_TARGET_RADIUS = 0.5
 
 LogScalarPrior = Callable[[float], float]
-LogRhoPrior = Callable[[NDArray[np.float_], NDArray[np.float_]], float]
+LogRhoPrior = Callable[[NDArray[np.float64], NDArray[np.float64]], float]
 
 
 def _zero_scalar(_: float) -> float:
     return 0.0
 
 
-def _zero_rho(_: NDArray[np.float_], __: NDArray[np.float_]) -> float:
+def _zero_rho(_: NDArray[np.float64], __: NDArray[np.float64]) -> float:
     return 0.0
 
 
@@ -46,8 +46,8 @@ def gaussian_logpdf(value: float, *, mean: float = 0.0, scale: float = 1.0) -> f
 
 
 def isotropic_gaussian_logpdf(
-    rho_bm: NDArray[np.float_],
-    rho_bg: NDArray[np.float_],
+    rho_bm: NDArray[np.float64],
+    rho_bg: NDArray[np.float64],
     *,
     scale: float = 1.0,
 ) -> float:

--- a/src/bubble/pmhmc/transforms.py
+++ b/src/bubble/pmhmc/transforms.py
@@ -8,20 +8,20 @@ from numpy.typing import NDArray
 
 from .types import BubbleParams, BubbleParamsUnconstrained
 
-ArrayLike = float | NDArray[np.float_]
+ArrayLike = float | NDArray[np.float64]
 
 PHI_B_LOWER = -0.999
 PHI_B_UPPER = 0.999
 
 
-def _softplus_raw(x: ArrayLike) -> NDArray[np.float_]:
+def _softplus_raw(x: ArrayLike) -> NDArray[np.float64]:
     """Raw softplus without minimum clipping."""
 
     x_arr = np.asarray(x, dtype=float)
     return np.log1p(np.exp(-np.abs(x_arr))) + np.maximum(x_arr, 0.0)
 
 
-def softplus(x: ArrayLike, min: float = 1e-6) -> NDArray[np.float_]:
+def softplus(x: ArrayLike, min: float = 1e-6) -> NDArray[np.float64]:
     """Numerically stable softplus transform with a lower bound."""
 
     x_arr = np.asarray(x, dtype=float)
@@ -31,7 +31,7 @@ def softplus(x: ArrayLike, min: float = 1e-6) -> NDArray[np.float_]:
     return out
 
 
-def inv_softplus(y: ArrayLike, min: float = 1e-6) -> NDArray[np.float_]:
+def inv_softplus(y: ArrayLike, min: float = 1e-6) -> NDArray[np.float64]:
     """Inverse of :func:`softplus` on the positive real line."""
 
     y_arr = np.asarray(y, dtype=float)
@@ -42,7 +42,7 @@ def inv_softplus(y: ArrayLike, min: float = 1e-6) -> NDArray[np.float_]:
 
 def tanh_to_interval(
     z: ArrayLike, a: float = PHI_B_LOWER, b: float = PHI_B_UPPER
-) -> NDArray[np.float_]:
+) -> NDArray[np.float64]:
     """Map real values to the open interval ``(a, b)`` using ``tanh``."""
 
     if not a < b:
@@ -55,7 +55,7 @@ def tanh_to_interval(
     return out
 
 
-def _log_sigmoid(x: NDArray[np.float_]) -> NDArray[np.float_]:
+def _log_sigmoid(x: NDArray[np.float64]) -> NDArray[np.float64]:
     """Stable computation of ``log(sigmoid(x))``."""
 
     x_arr = np.asarray(x, dtype=float)
@@ -64,8 +64,8 @@ def _log_sigmoid(x: NDArray[np.float_]) -> NDArray[np.float_]:
 
 
 def renorm_rho(
-    z_rho_bm: NDArray[np.float_], z_rho_bg: NDArray[np.float_]
-) -> Tuple[NDArray[np.float_], NDArray[np.float_], float]:
+    z_rho_bm: NDArray[np.float64], z_rho_bg: NDArray[np.float64]
+) -> Tuple[NDArray[np.float64], NDArray[np.float64], float]:
     """Shrink unconstrained vectors to the open unit ball.
 
     The mapping ``v -> v / sqrt(1 + ||v||^2)`` ensures that the resulting
@@ -122,11 +122,18 @@ def unconstrained_to_constrained(
     return params, log_jacobian
 
 
+def constrain_params(u: BubbleParamsUnconstrained) -> Tuple[BubbleParams, float]:
+    """Compatibility wrapper mirroring the legacy API name."""
+
+    return unconstrained_to_constrained(u)
+
+
 __all__ = [
     "softplus",
     "inv_softplus",
     "tanh_to_interval",
     "renorm_rho",
     "unconstrained_to_constrained",
+    "constrain_params",
 ]
 

--- a/src/bubble/pmhmc/types.py
+++ b/src/bubble/pmhmc/types.py
@@ -52,16 +52,16 @@ class BubbleData:
     """
 
     T: int
-    y_net_fund: NDArray[np.float_]
-    r_t: NDArray[np.float_]
-    m_t: NDArray[np.float_]
-    g_t: NDArray[np.float_]
-    h_t: NDArray[np.float_]
-    Dm_t: NDArray[np.float_]
-    Dg_t: NDArray[np.float_]
-    Sigma_m: NDArray[np.float_]
-    Sigma_g: NDArray[np.float_]
-    Sigma_gm: NDArray[np.float_]
+    y_net_fund: NDArray[np.float64]
+    r_t: NDArray[np.float64]
+    m_t: NDArray[np.float64]
+    g_t: NDArray[np.float64]
+    h_t: NDArray[np.float64]
+    Dm_t: NDArray[np.float64]
+    Dg_t: NDArray[np.float64]
+    Sigma_m: NDArray[np.float64]
+    Sigma_g: NDArray[np.float64]
+    Sigma_gm: NDArray[np.float64]
 
 
 @dataclass
@@ -87,8 +87,8 @@ class BubbleParams:
     mu_b: float
     phi_b: float
     sigma_h: float
-    rho_bm: NDArray[np.float_]
-    rho_bg: NDArray[np.float_]
+    rho_bm: NDArray[np.float64]
+    rho_bg: NDArray[np.float64]
 
 
 @dataclass
@@ -99,8 +99,8 @@ class BubbleParamsUnconstrained:
     z_mu_b: float
     z_phi_b: float
     z_sigma_h: float
-    z_rho_bm: NDArray[np.float_]
-    z_rho_bg: NDArray[np.float_]
+    z_rho_bm: NDArray[np.float64]
+    z_rho_bg: NDArray[np.float64]
 
 
 @dataclass
@@ -110,7 +110,7 @@ class PMHMCResult:
     params: BubbleParams
     log_like_hat: float
     accept_rate: float
-    draws_constrained: Dict[str, NDArray[np.float_]]
+    draws_constrained: Dict[str, NDArray[np.float64]]
     diagnostics: Dict[str, Any]
 
 

--- a/src/engine/__init__.py
+++ b/src/engine/__init__.py
@@ -1,0 +1,5 @@
+"""Sampling engines coordinating Gibbs sweeps."""
+
+from .run_bond_sweep import run_bond_sweep
+
+__all__ = ["run_bond_sweep"]

--- a/src/engine/run_bond_sweep.py
+++ b/src/engine/run_bond_sweep.py
@@ -1,0 +1,136 @@
+"""Full Gibbs sweep for the bond sub-model."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Tuple
+
+import jax
+
+from sampling.hmc_block import HMCConfig, HMCCache, NUTSBlock
+from sampling.diagnostics import write_jsonl
+
+
+def _require(mapping: Dict[str, Any], name: str) -> Any:
+    if name not in mapping or mapping[name] is None:
+        raise KeyError(f"Missing required entry '{name}' in state/context")
+    return mapping[name]
+
+
+def _logpost_block3a(theta_c: Any, ctx: Dict[str, Any]) -> Tuple[jax.Array, Dict[str, Any]]:
+    reconstruct = _require(ctx, "reconstruct_theta")
+    theta_full = reconstruct(theta_c, ctx["theta_rest"])
+    loglike_fn = _require(ctx, "loglikelihood")
+    logprior_fn = _require(ctx, "logprior")
+    loglik = loglike_fn(theta_full, ctx)
+    logprior = logprior_fn(theta_c, ctx.get("priors"))
+    return loglik + logprior, {"loglik": loglik, "logprior": logprior}
+
+
+def _logpost_block3b(theta_c: Any, ctx: Dict[str, Any]) -> Tuple[jax.Array, Dict[str, Any]]:
+    reconstruct = _require(ctx, "reconstruct_theta")
+    theta_full = reconstruct(theta_c, ctx["theta_rest"])
+    loglike_fn = _require(ctx, "loglikelihood")
+    logprior_fn = _require(ctx, "logprior")
+    loglik = loglike_fn(theta_full, ctx)
+    logprior = logprior_fn(theta_c, ctx.get("priors"))
+    return loglik + logprior, {"loglik": loglik, "logprior": logprior}
+
+
+def run_bond_sweep(
+    rng_key: jax.Array,
+    state: Dict[str, Any],
+    caches: Dict[str, HMCCache],
+    cfg_blocks: Dict[str, HMCConfig],
+    save_diag_path: str = "results/diagnostics/bond_sweep.jsonl",
+) -> Tuple[Dict[str, Any], Dict[str, HMCCache]]:
+    """Execute blocks 3a–3e for a single Gibbs sweep."""
+
+    t0 = time.perf_counter()
+    key = rng_key
+
+    # ----- Block 3a -----
+    key, subkey = jax.random.split(key)
+    ctx3a = {
+        "theta_rest": state.get("theta"),
+        "loglikelihood": state.get("loglikelihood_block3a"),
+        "logprior": state.get("logprior_block3a"),
+        "priors": state.get("priors"),
+        "reconstruct_theta": state.get("reconstruct_theta_3a"),
+    }
+    if ctx3a["loglikelihood"] is None:
+        ctx3a["loglikelihood"] = state.get("loglikelihood")
+    nuts3a = NUTSBlock(
+        _logpost_block3a,
+        _require(state, "transform_3a"),
+        _require(state, "inv_transform_3a"),
+        cfg_blocks["3a"],
+    )
+    theta3a_new, diag3a, cache3a = nuts3a.warmup_and_draw(
+        _require(state, "theta_block3a"),
+        caches.get("3a"),
+        ctx3a,
+        subkey,
+    )
+    state["theta_block3a"] = theta3a_new
+    state["theta"] = _require(ctx3a, "reconstruct_theta")(theta3a_new, state["theta"])
+
+    # ----- Block 3b -----
+    key, subkey = jax.random.split(key)
+    ctx3b = {
+        "theta_rest": state.get("theta"),
+        "loglikelihood": state.get("loglikelihood_block3b"),
+        "logprior": state.get("logprior_block3b"),
+        "priors": state.get("priors"),
+        "reconstruct_theta": state.get("reconstruct_theta_3b"),
+    }
+    if ctx3b["loglikelihood"] is None:
+        ctx3b["loglikelihood"] = state.get("loglikelihood")
+    nuts3b = NUTSBlock(
+        _logpost_block3b,
+        _require(state, "transform_3b"),
+        _require(state, "inv_transform_3b"),
+        cfg_blocks["3b"],
+    )
+    theta3b_new, diag3b, cache3b = nuts3b.warmup_and_draw(
+        _require(state, "theta_block3b"),
+        caches.get("3b"),
+        ctx3b,
+        subkey,
+    )
+    state["theta_block3b"] = theta3b_new
+    state["theta"] = _require(ctx3b, "reconstruct_theta")(theta3b_new, state["theta"])
+
+    # ----- Block 3c -----
+    key, subkey = jax.random.split(key)
+    draw_g_fn = _require(state, "draw_block3c")
+    g_new, extra_new, dk_diag = draw_g_fn(subkey, state)
+    state.update(extra_new)
+    state["g"] = g_new
+
+    # ----- Block 3d -----
+    key, subkey = jax.random.split(key)
+    draw_h_fn = _require(state, "draw_block3d")
+    h_new, pg_diag = draw_h_fn(subkey, state)
+    state["h"] = h_new
+
+    # ----- Block 3e -----
+    cov_update_fn = _require(state, "draw_cov_blocks")
+    state = cov_update_fn(state)
+
+    caches["3a"] = cache3a
+    caches["3b"] = cache3b
+
+    diag_record = {
+        "phase": "bond_sweep",
+        "time_sec": time.perf_counter() - t0,
+        "diag_3a": diag3a,
+        "diag_3b": diag3b,
+        "dk": dk_diag,
+        "pgas": pg_diag,
+    }
+    write_jsonl(save_diag_path, diag_record)
+    return state, caches
+
+
+__all__ = ["run_bond_sweep"]

--- a/src/sampling/__init__.py
+++ b/src/sampling/__init__.py
@@ -1,0 +1,5 @@
+"""Sampling utilities for HMC-within-Gibbs blocks."""
+
+from .hmc_block import HMCConfig, HMCCache, NUTSBlock
+
+__all__ = ["HMCConfig", "HMCCache", "NUTSBlock"]

--- a/src/sampling/diagnostics.py
+++ b/src/sampling/diagnostics.py
@@ -1,0 +1,21 @@
+"""Utility helpers for writing diagnostics to disk."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+
+def write_jsonl(path: str, record: Dict[str, Any]) -> None:
+    """Append ``record`` as a JSON document to ``path``."""
+
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as handle:
+        json.dump(record, handle)
+        handle.write("\n")
+
+
+__all__ = ["write_jsonl"]

--- a/src/sampling/hmc_block.py
+++ b/src/sampling/hmc_block.py
@@ -1,0 +1,181 @@
+"""Generic NUTS block driver with change-of-variable transforms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Tuple
+
+import blackjax
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+PyTree = Any
+
+
+@dataclass
+class HMCConfig:
+    """Configuration for a single HMC-within-Gibbs block."""
+
+    target_accept: float = 0.85
+    max_treedepth: int = 10
+    dense_mass: bool = False
+    warmup_long: int = 400
+    warmup_refresh: int = 50
+    num_draws: int = 1
+    chees_batch: int = 50
+    chees_tol: float = 0.05
+    init_step_size: float = 0.1
+
+
+@dataclass
+class HMCCache:
+    """Cache holding adapted step-size and mass matrix."""
+
+    step_size: float | None = None
+    inv_mass_matrix: jnp.ndarray | None = None
+    dense_mass: bool = False
+
+
+def _ebfmi(kinetic_energies: jnp.ndarray) -> float:
+    """Compute the energy Bayesian fraction of missing information."""
+
+    if kinetic_energies.size < 2:
+        return float("nan")
+    diffs = jnp.diff(kinetic_energies)
+    numerator = jnp.mean(diffs**2)
+    denominator = jnp.var(kinetic_energies) + 1e-12
+    return float(numerator / denominator)
+
+
+def _ess_batch_means(samples: jnp.ndarray) -> float:
+    """Cheap batch-means effective sample size estimate."""
+
+    if samples.ndim == 1:
+        series = samples
+    else:
+        series = samples.reshape(samples.shape[0], -1)
+    n = series.shape[0]
+    if n < 20:
+        return float(n)
+    m = int(jnp.sqrt(n))
+    b = n // m
+    trimmed = series[: b * m]
+    batch_means = trimmed.reshape(m, b, -1).mean(axis=1)
+    overall_var = jnp.var(trimmed, axis=0)
+    batch_var = jnp.var(batch_means, axis=0)
+    ess = n * overall_var / (b * batch_var + 1e-12)
+    return float(jnp.mean(ess))
+
+
+class NUTSBlock:
+    """Wraps a conditional log-posterior defined on unconstrained parameters."""
+
+    def __init__(
+        self,
+        logprob_fn: Callable[[PyTree, Dict[str, Any]], Tuple[jnp.ndarray, Dict[str, Any]]],
+        transform: Callable[[PyTree], Tuple[PyTree, float]],
+        inv_transform: Callable[[PyTree], PyTree],
+        cfg: HMCConfig,
+    ) -> None:
+        self.logprob_fn = logprob_fn
+        self.transform = transform
+        self.inv_transform = inv_transform
+        self.cfg = cfg
+
+    def _logprob_u(self, theta_u: PyTree, context: Dict[str, Any]) -> jnp.ndarray:
+        theta_c, logabsdet = self.transform(theta_u)
+        logprob, _ = self.logprob_fn(theta_c, context)
+        return logprob + logabsdet
+
+    def warmup_and_draw(
+        self,
+        init_theta_c: PyTree,
+        cache: HMCCache | None,
+        context: Dict[str, Any],
+        key: jax.Array,
+    ) -> Tuple[PyTree, Dict[str, Any], HMCCache]:
+        """Run warm-up (with cache reuse) and draw ``num_draws`` samples."""
+
+        theta_u0 = self.inv_transform(init_theta_c)
+        logprob = lambda th: self._logprob_u(th, context)
+
+        use_dense = self.cfg.dense_mass or (cache.dense_mass if cache else False)
+        init_step = cache.step_size if cache and cache.step_size is not None else self.cfg.init_step_size
+
+        n_adapt = self.cfg.warmup_long if cache is None or cache.step_size is None else self.cfg.warmup_refresh
+        n_adapt = max(int(n_adapt), 0)
+
+        adapt_key, draw_key = jax.random.split(key)
+        adapt = blackjax.window_adaptation(
+            blackjax.nuts,
+            logprob,
+            is_mass_matrix_diagonal=not use_dense,
+            initial_step_size=float(init_step),
+            target_acceptance_rate=self.cfg.target_accept,
+            max_num_doublings=self.cfg.max_treedepth,
+        )
+        adapt_res, adapt_info = adapt.run(adapt_key, theta_u0, n_adapt if n_adapt > 0 else 1)
+        warmup_state = adapt_res.state
+        params = adapt_res.parameters
+
+        energies = jnp.asarray(adapt_info.info.energy)
+        ebfmi = _ebfmi(energies)
+        warmup_accept = float(jnp.mean(jnp.asarray(adapt_info.info.acceptance_rate)))
+
+        nuts_kernel = blackjax.nuts(
+            logprob,
+            step_size=params["step_size"],
+            inverse_mass_matrix=params["inverse_mass_matrix"],
+            max_num_doublings=params.get("max_num_doublings", self.cfg.max_treedepth),
+        )
+
+        draws_u = []
+        accepts = []
+        divergences = []
+        depths = []
+        state_draw = warmup_state
+        for _ in range(max(1, int(self.cfg.num_draws))):
+            draw_key, step_key = jax.random.split(draw_key)
+            state_draw, info = nuts_kernel.step(step_key, state_draw)
+            draws_u.append(jnp.asarray(state_draw.position))
+            accepts.append(float(info.acceptance_rate))
+            divergences.append(bool(info.is_divergent))
+            depths.append(int(info.num_trajectory_expansions))
+
+        draws_arr = jnp.stack(draws_u, axis=0)
+        ess_proxy = _ess_batch_means(draws_arr)
+
+        theta_samples = [self.transform(u)[0] for u in draws_u]
+        theta_last = theta_samples[-1]
+
+        inv_mass = jnp.asarray(params["inverse_mass_matrix"])
+        if use_dense:
+            inv_mass_np = np.asarray(inv_mass)
+            eigs_inv = np.linalg.eigvalsh(inv_mass_np)
+        else:
+            eigs_inv = np.asarray(inv_mass)
+        eigs_mass = 1.0 / np.clip(eigs_inv, 1e-12, None)
+
+        diag = {
+            "accept_rate": float(np.mean(accepts)) if accepts else float("nan"),
+            "warmup_accept_rate": warmup_accept,
+            "max_treedepth": int(np.max(depths)) if depths else 0,
+            "divergences": int(np.sum(divergences)) if divergences else 0,
+            "ebfmi": ebfmi,
+            "ess_proxy": ess_proxy,
+            "step_size": float(params["step_size"]),
+            "mass_matrix_eigs": eigs_mass.tolist(),
+            "warmup_steps": int(n_adapt),
+            "dense_mass": bool(use_dense),
+        }
+
+        new_cache = HMCCache(
+            step_size=float(params["step_size"]),
+            inv_mass_matrix=jnp.asarray(params["inverse_mass_matrix"]),
+            dense_mass=bool(use_dense),
+        )
+        return theta_last, diag, new_cache
+
+
+__all__ = ["HMCConfig", "HMCCache", "NUTSBlock"]

--- a/src/sampling/transforms.py
+++ b/src/sampling/transforms.py
@@ -1,0 +1,141 @@
+"""Transform utilities for HMC blocks."""
+
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+import jax
+import jax.numpy as jnp
+
+_EPS = 1e-12
+
+
+def _ordered_unit_interval(z: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
+    """Return cumulative stick-breaking map and log-Jacobian."""
+
+    z = jnp.asarray(z, dtype=jnp.float64)
+
+    def _body(carry, z_i):
+        cumulative, remaining, log_jac = carry
+        v = jax.nn.sigmoid(z_i)
+        contrib = v * remaining
+        new_cumulative = cumulative + contrib
+        new_remaining = remaining * (1.0 - v)
+        log_jac_inc = jnp.log(v * (1.0 - v) + _EPS) + jnp.log(remaining + _EPS)
+        return (new_cumulative, new_remaining, log_jac + log_jac_inc), new_cumulative
+
+    init = (jnp.array(0.0, dtype=z.dtype), jnp.array(1.0, dtype=z.dtype), jnp.array(0.0, dtype=z.dtype))
+    (final_state, _remaining, log_jac), ordered = jax.lax.scan(_body, init, z)
+    del final_state, _remaining
+    return ordered, log_jac
+
+
+def _inverse_ordered_unit_interval(ordered: jnp.ndarray) -> jnp.ndarray:
+    """Inverse of :func:`_ordered_unit_interval` returning unconstrained vector."""
+
+    ordered = jnp.asarray(ordered, dtype=jnp.float64)
+
+    def _body(carry, o_i):
+        previous, remaining = carry
+        increment = (o_i - previous) / (remaining + _EPS)
+        increment = jnp.clip(increment, 1e-9, 1.0 - 1e-9)
+        z_i = jax.scipy.special.logit(increment)
+        new_remaining = remaining * (1.0 - increment)
+        return (o_i, new_remaining), z_i
+
+    init = (jnp.array(0.0, dtype=ordered.dtype), jnp.array(1.0, dtype=ordered.dtype))
+    (_, _), z = jax.lax.scan(_body, init, ordered)
+    return z
+
+
+def eigenvalues_q_transform(zeta: jnp.ndarray, delta: float, eps: float = 1e-3) -> Tuple[jnp.ndarray, float]:
+    """Map unconstrained values to ordered, spectrally bounded eigenvalues."""
+
+    if zeta.ndim != 1:
+        raise ValueError("zeta must be a vector")
+    rho_max = (1.0 - float(eps)) / float(delta)
+    ordered_unit, log_jac = _ordered_unit_interval(zeta)
+    ordered_unit = jnp.clip(ordered_unit, 1e-9, 1.0 - 1e-9)
+    eta = jax.scipy.special.logit(ordered_unit)
+    tanh_eta = jnp.tanh(eta)
+    lam = rho_max * tanh_eta
+
+    log_jac += zeta.size * jnp.log(rho_max)
+    log_jac += jnp.sum(jnp.log1p(-tanh_eta**2 + _EPS))
+    log_jac -= jnp.sum(jnp.log(ordered_unit) + jnp.log1p(-ordered_unit))
+    return lam, float(log_jac)
+
+
+def inv_eigenvalues_q_transform(lambda_vec: jnp.ndarray, delta: float, eps: float = 1e-3) -> jnp.ndarray:
+    """Inverse of :func:`eigenvalues_q_transform`."""
+
+    rho_max = (1.0 - float(eps)) / float(delta)
+    x = jnp.clip(lambda_vec / rho_max, -0.999999, 0.999999)
+    eta = jnp.arctanh(x)
+    ordered = jax.nn.sigmoid(eta)
+    return _inverse_ordered_unit_interval(ordered)
+
+
+def _infer_cholesky_dim(num_params: int, unit_diag: bool) -> int:
+    disc = 1 + 8 * num_params
+    if unit_diag:
+        n = (1.0 + math.sqrt(disc)) / 2.0
+    else:
+        n = (-1.0 + math.sqrt(disc)) / 2.0
+    if n <= 0:
+        raise ValueError("Invalid parameter count for triangular matrix")
+    return int(round(n))
+
+
+def cholesky_unconstr_to_lower(u: jnp.ndarray, unit_diag: bool = False) -> Tuple[jnp.ndarray, float]:
+    """Map unconstrained vector to lower-triangular matrix."""
+
+    u = jnp.asarray(u, dtype=jnp.float64)
+    n = _infer_cholesky_dim(u.size, unit_diag)
+    L = jnp.zeros((n, n), dtype=jnp.float64)
+    idx = 0
+    log_jac = jnp.array(0.0, dtype=jnp.float64)
+    for i in range(n):
+        for j in range(i + 1):
+            if i == j:
+                if unit_diag:
+                    L = L.at[i, i].set(1.0)
+                else:
+                    x = u[idx]
+                    val = jax.nn.softplus(x)
+                    log_jac = log_jac + jnp.log(jax.nn.sigmoid(x) + _EPS)
+                    L = L.at[i, i].set(val)
+                    idx += 1
+            else:
+                L = L.at[i, j].set(u[idx])
+                idx += 1
+    return L, float(log_jac)
+
+
+def lower_to_unconstr(L: jnp.ndarray, unit_diag: bool = False) -> jnp.ndarray:
+    """Inverse map of :func:`cholesky_unconstr_to_lower`."""
+
+    L = jnp.asarray(L, dtype=jnp.float64)
+    n = L.shape[0]
+    elems = []
+    for i in range(n):
+        for j in range(i + 1):
+            if i == j:
+                if unit_diag:
+                    continue
+                d = jnp.clip(L[i, i], _EPS, None)
+                elems.append(jnp.log(jnp.expm1(d)))
+            else:
+                elems.append(L[i, j])
+    if not elems:
+        return jnp.zeros((0,), dtype=jnp.float64)
+    return jnp.stack(elems)
+
+
+__all__ = [
+    "eigenvalues_q_transform",
+    "inv_eigenvalues_q_transform",
+    "cholesky_unconstr_to_lower",
+    "lower_to_unconstr",
+]


### PR DESCRIPTION
## Summary
- add reusable NUTS block implementation with diagnostics/transforms
- build a real bond sweep engine that wires HMC blocks, DK draws, PG-AS, and diagnostics logging
- align bubble PMHMC typing utilities with NumPy 2.0 by using float64 aliases and keeping legacy APIs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2f126f100832084e5213583c142b4