### PR TITLE
Add market data loader and factor draw utility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "rich",
   "tqdm",
   "typing-extensions",
+  "h5py",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tqdm>=4.66
 jax>=0.4
 blackjax>=1.1
 numba>=0.59
+h5py>=3.11

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,3 +1,11 @@
 """Data loading helpers for MCMC sweeps."""
 
-__all__ = ["load_observed_inputs", "sample_m"]
+from .market_data import get_fac_draw_slice, load_market_data, MarketData
+
+__all__ = [
+    "load_observed_inputs",
+    "load_market_data",
+    "MarketData",
+    "sample_m",
+    "get_fac_draw_slice",
+]

--- a/src/data/market_data.py
+++ b/src/data/market_data.py
@@ -1,0 +1,122 @@
+"""Utilities for loading bond and equity market data files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import h5py
+import numpy as np
+import pandas as pd
+
+
+def _require_file(path: str | Path) -> Path:
+    """Return the path if it exists, otherwise raise ``FileNotFoundError``."""
+
+    resolved = Path(path)
+    if not resolved.exists():
+        raise FileNotFoundError(f"Required file not found: {resolved}")
+    return resolved
+
+
+def _first(iterable: Iterable[str]) -> str:
+    try:
+        return next(iter(iterable))
+    except StopIteration as exc:  # pragma: no cover - defensive guard
+        raise KeyError("HDF5 file does not contain any datasets") from exc
+
+
+@dataclass(frozen=True)
+class MarketData:
+    """Container for parsed market data arrays."""
+
+    bond_yields: np.ndarray
+    sp500_price: np.ndarray
+    sp500_div: np.ndarray
+    log_div_grow: np.ndarray
+
+
+def load_market_data(
+    bond_yields_csv: str | Path,
+    sp500_csv: str | Path,
+) -> MarketData:
+    """Load the market data CSV files into numpy arrays.
+
+    Parameters
+    ----------
+    bond_yields_csv:
+        Path to ``bond_yields.csv`` containing a header row and dates in the
+        first column. Rows are returned from the first data row onwards while
+        omitting the date column.
+    sp500_csv:
+        Path to ``sp500_data.csv`` containing a header row with price and
+        dividend information. The function skips the first two data rows and
+        returns the remaining values for the price, dividend, and log dividend
+        growth columns.
+    """
+
+    bond_df = pd.read_csv(_require_file(bond_yields_csv))
+    bond_yields = (
+        bond_df.iloc[:, 1:]
+        .apply(pd.to_numeric, errors="coerce")
+        .to_numpy(dtype=float, copy=False)
+    )
+
+    sp500_df = pd.read_csv(_require_file(sp500_csv))
+    # Skip the first two data rows as requested (rows 3-end in 1-based indexing).
+    data_slice = sp500_df.iloc[2:]
+    numeric = data_slice.apply(pd.to_numeric, errors="coerce")
+    sp500_price = numeric.iloc[:, 0].to_numpy(dtype=float, copy=False)
+    sp500_div = numeric.iloc[:, 1].to_numpy(dtype=float, copy=False)
+    log_div_grow = numeric.iloc[:, 3].to_numpy(dtype=float, copy=False)
+
+    return MarketData(
+        bond_yields=bond_yields,
+        sp500_price=sp500_price,
+        sp500_div=sp500_div,
+        log_div_grow=log_div_grow,
+    )
+
+
+def get_fac_draw_slice(
+    mat_file: str | Path,
+    nn: int,
+    *,
+    dataset: str | None = None,
+) -> np.ndarray:
+    """Return the ``nn``-th slice of the factor draws tensor using ``h5py``.
+
+    The ``fac_draws_K4.mat`` file stores a tensor with shape ``(4, 547, N)``.
+    Rather than loading the entire tensor, this helper reads only the
+    two-dimensional slice requested by ``nn``.
+    """
+
+    if nn < 0:
+        raise ValueError("'nn' must be a non-negative integer")
+
+    mat_path = _require_file(mat_file)
+    with h5py.File(mat_path, "r") as handle:
+        dataset_name = dataset or _first(handle.keys())
+        if dataset_name not in handle:
+            available = ", ".join(handle.keys()) or "<none>"
+            raise KeyError(
+                f"Dataset '{dataset_name}' not found in {mat_path}. "
+                f"Available: {available}"
+            )
+
+        data = handle[dataset_name]
+        if data.ndim != 3:
+            raise ValueError(
+                f"Expected a 3D tensor in dataset '{dataset_name}', got shape {data.shape}"
+            )
+        if nn >= data.shape[2]:
+            raise IndexError(
+                f"Index {nn} is out of bounds for axis 2 with size {data.shape[2]}"
+            )
+
+        # h5py reads only the requested slice into memory.
+        slice_ = data[:, :, nn]
+
+    return np.asarray(slice_, dtype=float)
+

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+import h5py
+
+from data.market_data import get_fac_draw_slice, load_market_data
+
+
+def test_load_market_data(tmp_path):
+    bond_csv = tmp_path / "bond_yields.csv"
+    bond_df = pd.DataFrame(
+        {
+            "Date": ["2020-01-01", "2020-02-01"],
+            "TB3MS": [1.0, 3.0],
+            "TB6MS": [2.0, 4.0],
+        }
+    )
+    bond_df.to_csv(bond_csv, index=False)
+
+    sp500_csv = tmp_path / "sp500_data.csv"
+    sp500_df = pd.DataFrame(
+        {
+            "Price": [118.4, 114.2, 112.4, 110.3],
+            "Dividend": [3.16, 3.16, 3.17, 3.19],
+            "DATE": ["", "1973-02-01", "1973-03-01", "1973-04-01"],
+            "log_div_grow": [np.nan, 0.002, 0.003, 0.004],
+        }
+    )
+    sp500_df.to_csv(sp500_csv, index=False)
+
+    data = load_market_data(bond_csv, sp500_csv)
+
+    np.testing.assert_allclose(data.bond_yields, np.array([[1.0, 2.0], [3.0, 4.0]]))
+    np.testing.assert_allclose(data.sp500_price, np.array([112.4, 110.3]))
+    np.testing.assert_allclose(data.sp500_div, np.array([3.17, 3.19]))
+    np.testing.assert_allclose(data.log_div_grow, np.array([0.003, 0.004]))
+
+
+def test_get_fac_draw_slice(tmp_path):
+    mat_path = tmp_path / "fac_draws_K4.mat"
+    data = np.arange(4 * 547 * 3, dtype=float).reshape(4, 547, 3)
+
+    with h5py.File(mat_path, "w") as handle:
+        handle.create_dataset("draws", data=data)
+
+    slice_ = get_fac_draw_slice(mat_path, 1, dataset="draws")
+    np.testing.assert_allclose(slice_, data[:, :, 1])
+
+    # Default dataset selection should also work.
+    slice_default = get_fac_draw_slice(mat_path, 2)
+    np.testing.assert_allclose(slice_default, data[:, :, 2])


### PR DESCRIPTION
## Summary
- add a dedicated market data loader that parses bond yields and S&P 500 CSV inputs into numpy arrays
- provide an h5py-based helper to fetch a single slice from the fac_draws_K4 tensor without loading the whole file
- cover the new helpers with pytest cases and declare h5py as an explicit dependency

## Testing
- pytest tests/test_market_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d54e40d6f083208dc890b3e01ad0a7