### PR TITLE
Expand block3a Kalman design to full state system

### DIFF
--- a/src/cw2017/kalman/design.py
+++ b/src/cw2017/kalman/design.py
@@ -1,0 +1,223 @@
+"""State-space design utilities for the CW2017 bond-pricing model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from .utils import cholesky_psd, compute_diag_scales
+
+Array = jnp.ndarray
+
+
+@dataclass(frozen=True)
+class Block3aKalmanDesign:
+    """Container holding the linear-dynamical-system inputs for block 3a."""
+
+    observations: Array
+    measurement_matrix: Array
+    measurement_noise_chol: Array
+    transition_matrix: Array
+    state_offsets: Array
+    process_noise_chol: Array
+    initial_mean: Array
+    initial_sqrt_cov: Array
+
+
+def _asarray(x: Array) -> Array:
+    return jnp.asarray(x, dtype=jnp.float64)
+
+
+def build_block3a_design(
+    params3a: any,
+    fixed: Dict[str, Array],
+    measurement_terms: Tuple[Array, Array, Array, Array, Array],
+    y_t: Array,
+    m_t: Array,
+    h_t: Array,
+    maturities: Iterable[int],
+) -> Block3aKalmanDesign:
+    """Return the arrays required by the square-root Kalman filter.
+
+    The construction follows the six-state system in Section 1.3 of
+    :mod:`docs/model_writeup`, matching Algorithm Overview §3.1.d.  The
+    observation stack is ``[m_t, y_t, h_t]`` while the dynamic state vector is
+    ``[m_t, g_t, h_t, \bar{\mu}_m, \bar{\mu}_g^u, \bar{\mu}_g^{\mathbb{Q},u}]``.
+    """
+
+    del maturities  # The measurement terms already encode the maturity set.
+
+    A0, A1, B, M0Q, M1Q = measurement_terms
+    y_t = _asarray(y_t)
+    m_t = _asarray(m_t)
+    h_t = _asarray(h_t)
+
+    T = y_t.shape[0]
+    d_m = m_t.shape[1]
+    d_y = y_t.shape[1]
+    d_h = h_t.shape[1]
+    d_g = B.shape[1]
+
+    M1 = _asarray(fixed["M1"])
+    d_mu_gu = M1.shape[1]
+    d_mu_gq = M1Q.shape[1]
+
+    mu_m_bar = _asarray(fixed["mu_m_bar"])
+    mu_gu_bar = _asarray(fixed["mu_g^u_bar"])
+    mu_gq_bar = _asarray(fixed["mu_g^{Q,u}"])
+    mu_h_bar = _asarray(fixed["mu_h_bar"])
+
+    Phi_m = _asarray(fixed["Phi_m"])
+    Phi_mg = _asarray(fixed["Phi_mg"])
+    Phi_mh = _asarray(fixed["Phi_mh"])
+    Phi_h = _asarray(fixed["Phi_h"])
+
+    Phi_blocks = params3a.PhiP_blocks
+    Phi_gm = _asarray(Phi_blocks.Phi_gm)
+    Phi_gh = _asarray(Phi_blocks.Phi_gh)
+    Phi_g = _asarray(Phi_blocks.Phi_gg)
+
+    bar_blocks = fixed["bar"]
+    bar_mm = _asarray(bar_blocks["mm"])
+    bar_mg = _asarray(bar_blocks["mg"])
+    bar_mh = _asarray(bar_blocks["mh"])
+    bar_gm = _asarray(bar_blocks["gm"])
+    bar_gg = _asarray(bar_blocks["gg"])
+    bar_gh = _asarray(bar_blocks["gh"])
+    bar_hh = _asarray(bar_blocks["hh"])
+
+    Sigma_m = _asarray(fixed["Sigma_m"])
+    Sigma_gm = _asarray(fixed["Sigma_gm"])
+    Sigma_hm = _asarray(fixed["Sigma_hm"])
+    Sigma_hg = _asarray(fixed["Sigma_hg"])
+    Sigma_h = _asarray(fixed["Sigma_h"])
+    Sigma_g = _asarray(params3a.Sigma_g)
+
+    Gamma0 = _asarray(params3a.Gamma0)
+    Gamma1 = _asarray(params3a.Gamma1)
+
+    # Observation residuals after subtracting the deterministic offsets.
+    obs_offset_y = (_asarray(A0) + _asarray(A1) @ _asarray(M0Q)).reshape(-1)
+    obs_offset = jnp.concatenate(
+        [
+            jnp.zeros((d_m,), dtype=jnp.float64),
+            obs_offset_y,
+            jnp.zeros((d_h,), dtype=jnp.float64),
+        ]
+    )
+    obs_offset = jnp.broadcast_to(obs_offset, (T, d_m + d_y + d_h))
+    observations = jnp.concatenate(
+        [m_t, y_t, h_t], axis=1
+    ) - obs_offset
+
+    state_dim = d_m + d_g + d_h + d_m + d_mu_gu + d_mu_gq
+
+    # Measurement matrix following the block structure in Section 1.3.
+    measurement_matrix = jnp.zeros((d_m + d_y + d_h, state_dim), dtype=jnp.float64)
+    row_m = slice(0, d_m)
+    row_y = slice(d_m, d_m + d_y)
+    row_h = slice(d_m + d_y, d_m + d_y + d_h)
+    idx_m = slice(0, d_m)
+    idx_g = slice(d_m, d_m + d_g)
+    idx_h = slice(d_m + d_g, d_m + d_g + d_h)
+    idx_mu_m = slice(d_m + d_g + d_h, d_m + d_g + d_h + d_m)
+    idx_mu_gu = slice(idx_mu_m.stop, idx_mu_m.stop + d_mu_gu)
+    idx_mu_gq = slice(idx_mu_gu.stop, idx_mu_gu.stop + d_mu_gq)
+
+    measurement_matrix = measurement_matrix.at[row_m, idx_m].set(jnp.eye(d_m))
+    measurement_matrix = measurement_matrix.at[row_y, idx_g].set(_asarray(B))
+    measurement_matrix = measurement_matrix.at[row_y, idx_mu_gq].set(
+        _asarray(A1) @ _asarray(M1Q)
+    )
+    measurement_matrix = measurement_matrix.at[row_h, idx_h].set(jnp.eye(d_h))
+
+    # Observation noise: zero for m/h, Omega for the yields.
+    R = jnp.zeros((d_m + d_y + d_h, d_m + d_y + d_h), dtype=jnp.float64)
+    det_noise = 1e-6
+    det_sqrt = jnp.sqrt(det_noise)
+    if d_m > 0:
+        R = R.at[row_m, row_m].set(det_sqrt * jnp.eye(d_m, dtype=jnp.float64))
+    Omega_sqrt = jnp.sqrt(_asarray(params3a.Omega_diag))
+    R = R.at[row_y, row_y].set(
+        jnp.diag(Omega_sqrt)
+    )
+    if d_h > 0:
+        R = R.at[row_h, row_h].set(det_sqrt * jnp.eye(d_h, dtype=jnp.float64))
+
+    # Transition matrix in block form.
+    transition_matrix = jnp.zeros((state_dim, state_dim), dtype=jnp.float64)
+    transition_matrix = transition_matrix.at[idx_m, idx_m].set(Phi_m)
+    transition_matrix = transition_matrix.at[idx_m, idx_g].set(Phi_mg)
+    transition_matrix = transition_matrix.at[idx_m, idx_h].set(Phi_mh)
+    transition_matrix = transition_matrix.at[idx_m, idx_mu_m].set(bar_mm)
+    transition_matrix = transition_matrix.at[idx_m, idx_mu_gu].set(bar_mg)
+
+    transition_matrix = transition_matrix.at[idx_g, idx_m].set(Phi_gm)
+    transition_matrix = transition_matrix.at[idx_g, idx_g].set(Phi_g)
+    transition_matrix = transition_matrix.at[idx_g, idx_h].set(Phi_gh)
+    transition_matrix = transition_matrix.at[idx_g, idx_mu_m].set(bar_gm)
+    transition_matrix = transition_matrix.at[idx_g, idx_mu_gu].set(bar_gg)
+
+    transition_matrix = transition_matrix.at[idx_h, idx_h].set(Phi_h)
+
+    transition_matrix = transition_matrix.at[idx_mu_m, idx_mu_m].set(jnp.eye(d_m))
+    transition_matrix = transition_matrix.at[idx_mu_gu, idx_mu_gu].set(jnp.eye(d_mu_gu))
+    transition_matrix = transition_matrix.at[idx_mu_gq, idx_mu_gq].set(jnp.eye(d_mu_gq))
+
+    offset_vec = jnp.zeros((state_dim,), dtype=jnp.float64)
+    offset_vec = offset_vec.at[idx_m].set(bar_mh @ mu_h_bar)
+    offset_vec = offset_vec.at[idx_g].set(bar_gh @ mu_h_bar)
+    offset_vec = offset_vec.at[idx_h].set(bar_hh @ mu_h_bar)
+    state_offsets = jnp.broadcast_to(offset_vec, (T, state_dim))
+
+    # Diagonal scaling for ``D_{m,t}`` and ``D_{g,t}``.
+    diag_scales = compute_diag_scales(Gamma0, Gamma1, h_t)
+    diag_m = diag_scales[:, :d_m]
+    diag_g = diag_scales[:, d_m: d_m + d_g]
+
+    if d_m > 0:
+        h_lag = jnp.concatenate([h_t[:1], h_t[:-1]], axis=0)
+        gamma_last = Gamma1[d_m - 1]
+        last_exp = Gamma0[d_m - 1] + h_lag @ gamma_last
+        last_exp = jnp.clip(last_exp, -20.0, 20.0)
+        diag_last = jnp.exp(0.5 * last_exp)
+        diag_m = diag_m.at[:, d_m - 1].set(diag_last)
+
+    def process_chol(diag_m_t: Array, diag_g_t: Array) -> Array:
+        noise_dim = d_m + d_g + d_h
+        G = jnp.zeros((state_dim, noise_dim), dtype=jnp.float64)
+
+        G = G.at[idx_m, :d_m].set(Sigma_m * diag_m_t[None, :])
+        G = G.at[idx_g, :d_m].set(Sigma_gm * diag_m_t[None, :])
+        G = G.at[idx_g, d_m : d_m + d_g].set(Sigma_g * diag_g_t[None, :])
+        G = G.at[idx_h, :d_m].set(Sigma_hm)
+        G = G.at[idx_h, d_m : d_m + d_g].set(Sigma_hg)
+        G = G.at[idx_h, d_m + d_g :].set(Sigma_h)
+        cov = G @ G.T
+        return cholesky_psd(cov)
+
+    process_noise_chol = jax.vmap(process_chol)(diag_m, diag_g)
+
+    g0 = _asarray(fixed.get("g0_mean", jnp.zeros((d_g,), dtype=jnp.float64)))
+    initial_mean = jnp.concatenate(
+        [m_t[0], g0, h_t[0], mu_m_bar, mu_gu_bar, mu_gq_bar]
+    )
+    initial_sqrt_cov = process_noise_chol[0]
+
+    return Block3aKalmanDesign(
+        observations=observations,
+        measurement_matrix=measurement_matrix,
+        measurement_noise_chol=R,
+        transition_matrix=transition_matrix,
+        state_offsets=state_offsets,
+        process_noise_chol=process_noise_chol,
+        initial_mean=initial_mean,
+        initial_sqrt_cov=initial_sqrt_cov,
+    )
+
+
+__all__ = ["Block3aKalmanDesign", "build_block3a_design"]
+

--- a/src/cw2017/kalman/utils.py
+++ b/src/cw2017/kalman/utils.py
@@ -1,0 +1,40 @@
+"""Shared numerical utilities for the CW2017 Kalman routines."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.scipy.linalg as jsp
+
+Array = jnp.ndarray
+
+_JITTER = 1e-10
+
+
+def compute_diag_scales(Gamma0: Array, Gamma1: Array, h_vec: Array) -> Array:
+    """Return ``exp(0.5 * (Gamma0 + Gamma1 h_t))`` with clipping for stability."""
+
+    h_arr = jnp.asarray(h_vec, dtype=jnp.float64)
+    Gamma0_arr = jnp.asarray(Gamma0, dtype=jnp.float64)
+    Gamma1_arr = jnp.asarray(Gamma1, dtype=jnp.float64)
+
+    if h_arr.ndim == 1:
+        exponent = Gamma0_arr + h_arr @ Gamma1_arr.T
+    else:
+        exponent = Gamma0_arr + h_arr @ Gamma1_arr.T
+    exponent = jnp.clip(exponent, -20.0, 20.0)
+    return jnp.exp(0.5 * exponent)
+
+
+def symmetrize_psd(matrix: Array) -> Array:
+    return (matrix + matrix.T) * 0.5
+
+
+def cholesky_psd(matrix: Array) -> Array:
+    matrix = symmetrize_psd(matrix)
+    dim = matrix.shape[0]
+    jitter_eye = _JITTER * jnp.eye(dim, dtype=matrix.dtype)
+    return jsp.cholesky(matrix + jitter_eye, lower=True)
+
+
+__all__ = ["compute_diag_scales", "symmetrize_psd", "cholesky_psd"]
+

--- a/tests/test_block3a_design.py
+++ b/tests/test_block3a_design.py
@@ -1,0 +1,63 @@
+import jax.numpy as jnp
+
+from cw2017.kalman.design import build_block3a_design
+from cw2017.models.conditionals import unpack_params3a_unconstrained
+from cw2017.models.parameters import constrain_params3a
+from cw2017.equity.atsm_measurement import build_measurement_terms
+from test_block3a_smoke import block3a_setup
+
+
+def test_block3a_design_shapes(block3a_setup) -> None:
+    _, fixed, data, cfg, _warmup, info, maturities, init_vec = block3a_setup
+
+    params_u = unpack_params3a_unconstrained(init_vec, info, maturities)
+    params_c, _ = constrain_params3a(params_u, cfg, info)
+    measurement_terms = build_measurement_terms(params_c, fixed, maturities)
+
+    design = build_block3a_design(
+        params_c,
+        fixed,
+        measurement_terms,
+        data["y_t"],
+        fixed["m_t"],
+        fixed["h_t"],
+        maturities,
+    )
+
+    y_t = jnp.asarray(data["y_t"], dtype=jnp.float64)
+    m_t = jnp.asarray(fixed["m_t"], dtype=jnp.float64)
+    h_t = jnp.asarray(fixed["h_t"], dtype=jnp.float64)
+    Ng = int(info["Ng"])
+    dy = y_t.shape[1]
+    dm = m_t.shape[1]
+    dh = h_t.shape[1]
+    mu_gu_dim = fixed["M1"].shape[1]
+    mu_gq_dim = measurement_terms[4].shape[1]
+    state_dim = dm + Ng + dh + dm + mu_gu_dim + mu_gq_dim
+    obs_dim = dm + dy + dh
+    T = y_t.shape[0]
+
+    assert design.observations.shape == (T, obs_dim)
+    assert design.measurement_matrix.shape == (obs_dim, state_dim)
+    assert design.measurement_noise_chol.shape == (obs_dim, obs_dim)
+    assert design.process_noise_chol.shape == (T, state_dim, state_dim)
+    assert design.state_offsets.shape == (T, state_dim)
+    assert design.initial_mean.shape == (state_dim,)
+    assert design.initial_sqrt_cov.shape == (state_dim, state_dim)
+
+    # Noise rows corresponding to yields should be positive.
+    diag_entries = jnp.diag(design.measurement_noise_chol)
+    det_diag = jnp.concatenate(
+        [
+            diag_entries[:dm],
+            diag_entries[-dh:] if dh > 0 else jnp.array([], dtype=jnp.float64),
+        ]
+    )
+    assert jnp.allclose(det_diag, jnp.sqrt(1e-6), atol=1e-10)
+    assert jnp.all(diag_entries[dm : dm + dy] > 0.0)
+
+    # Initial covariance should match the first process noise.
+    assert jnp.allclose(
+        design.initial_sqrt_cov,
+        design.process_noise_chol[0],
+    )

--- a/tests/test_block3a_smoke.py
+++ b/tests/test_block3a_smoke.py
@@ -21,18 +21,59 @@ def block3a_setup():
     h_t = jax.random.normal(h_key, (T, d_h), dtype=jnp.float64) * 0.1
     y_t = jax.random.normal(y_key, (T, d_y), dtype=jnp.float64) * 0.1
 
-    Sigma_g = jnp.eye(3, dtype=jnp.float64)
+    d_g = 3
+    mu_gu_dim = 2
+    Sigma_g = jnp.eye(d_g, dtype=jnp.float64)
+    M1 = jnp.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0]], dtype=jnp.float64)
+    Phi_m = 0.95 * jnp.eye(d_m, dtype=jnp.float64)
+    Phi_mg = jnp.zeros((d_m, d_g), dtype=jnp.float64)
+    Phi_mh = jnp.zeros((d_m, d_h), dtype=jnp.float64)
+    Phi_h = 0.9 * jnp.eye(d_h, dtype=jnp.float64)
+    bar_mm = 0.05 * jnp.eye(d_m, dtype=jnp.float64)
+    bar_mg = 0.02 * jnp.ones((d_m, mu_gu_dim), dtype=jnp.float64)
+    bar_mh = 0.01 * jnp.ones((d_m, d_h), dtype=jnp.float64)
+    bar_gm = 0.03 * jnp.ones((d_g, d_m), dtype=jnp.float64)
+    bar_gg = 0.02 * jnp.ones((d_g, mu_gu_dim), dtype=jnp.float64)
+    bar_gh = 0.01 * jnp.ones((d_g, d_h), dtype=jnp.float64)
+    bar_hh = 0.05 * jnp.eye(d_h, dtype=jnp.float64)
+    Sigma_m = jnp.eye(d_m, dtype=jnp.float64)
+    Sigma_gm = jnp.zeros((d_g, d_m), dtype=jnp.float64)
+    Sigma_hm = jnp.zeros((d_h, d_m), dtype=jnp.float64)
+    Sigma_hg = jnp.zeros((d_h, d_g), dtype=jnp.float64)
+    Sigma_h = jnp.eye(d_h, dtype=jnp.float64)
     fixed = {
         "m_t": m_t,
         "h_t": h_t,
-        "mu_g": jnp.zeros(3, dtype=jnp.float64),
-        "Q_g^Q": jnp.eye(3, dtype=jnp.float64),
+        "mu_g": jnp.zeros(d_g, dtype=jnp.float64),
+        "Q_g^Q": jnp.eye(d_g, dtype=jnp.float64),
         "Lambda_g^Q": jnp.diag(jnp.array([0.9, 0.8, 0.7], dtype=jnp.float64)),
         "Sigma_g": Sigma_g,
-        "Gamma0": jnp.zeros(d_m + 3, dtype=jnp.float64),
-        "Gamma1": jnp.zeros((d_m + 3, d_h), dtype=jnp.float64),
+        "Gamma0": jnp.zeros(d_m + d_g, dtype=jnp.float64),
+        "Gamma1": jnp.zeros((d_m + d_g, d_h), dtype=jnp.float64),
         "mu_h_bar": jnp.zeros(d_h, dtype=jnp.float64),
-        "mu_g^{Q,u}": jnp.zeros(2, dtype=jnp.float64),
+        "mu_g^{Q,u}": jnp.zeros(mu_gu_dim, dtype=jnp.float64),
+        "mu_m_bar": jnp.zeros(d_m, dtype=jnp.float64),
+        "mu_g^u_bar": jnp.zeros(mu_gu_dim, dtype=jnp.float64),
+        "M1": M1,
+        "Phi_m": Phi_m,
+        "Phi_mg": Phi_mg,
+        "Phi_mh": Phi_mh,
+        "Phi_h": Phi_h,
+        "Sigma_m": Sigma_m,
+        "Sigma_gm": Sigma_gm,
+        "Sigma_hm": Sigma_hm,
+        "Sigma_hg": Sigma_hg,
+        "Sigma_h": Sigma_h,
+        "g0_mean": jnp.zeros(d_g, dtype=jnp.float64),
+        "bar": {
+            "mm": bar_mm,
+            "mg": bar_mg,
+            "mh": bar_mh,
+            "gm": bar_gm,
+            "gg": bar_gg,
+            "gh": bar_gh,
+            "hh": bar_hh,
+        },
     }
     data = {"y_t": y_t}
     cfg = {"rho_max": 0.995, "priors_3a": {}}


### PR DESCRIPTION
## Summary
- rebuild the block 3a Kalman design to assemble the full six-state measurement and transition system from Algorithm Overview §3.1.d, including deterministic offsets, identity blocks for static means, and time-varying process noise with the correlated m/g/h innovations
- add a reusable diagonal-scale helper with tighter clipping to stabilize the volatility-driven diffusion matrices and update the SR-Kalman filter import path accordingly
- refresh the block 3a tests to exercise the expanded design dimensions, deterministic observation jitter, and fixture inputs required by the full state-space specification

## Testing
- pytest tests/test_block3a_design.py tests/test_block3a_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68d55f932ef4832091df0ae74023656e