### PR TITLE
Extend block3a HMC to sample volatility mean

### DIFF
--- a/src/cw2017/equity/atsm_measurement.py
+++ b/src/cw2017/equity/atsm_measurement.py
@@ -163,7 +163,6 @@ def build_measurement_terms(
 
     QgQ = _as_array(fixed["Q_g^Q"])
     Lambda_gQ = fixed["Lambda_g^Q"]
-    mu_h_bar = _as_array(fixed["mu_h_bar"])
     Sigma_g = params3a.Sigma_g
     Gamma0 = params3a.Gamma0
     Gamma1 = params3a.Gamma1
@@ -173,7 +172,7 @@ def build_measurement_terms(
         Sigma_g,
         Gamma0,
         Gamma1,
-        np.asarray(mu_h_bar),
+        params3a.mu_h_bar,
         d_m,
         d_g,
     )

--- a/src/cw2017/kalman/design.py
+++ b/src/cw2017/kalman/design.py
@@ -68,7 +68,7 @@ def build_block3a_design(
     mu_m_bar = _asarray(fixed["mu_m_bar"])
     mu_gu_bar = _asarray(fixed["mu_g^u_bar"])
     mu_gq_bar = _asarray(fixed["mu_g^{Q,u}"])
-    mu_h_bar = _asarray(fixed["mu_h_bar"])
+    mu_h_bar = _asarray(params3a.mu_h_bar)
 
     Phi_m = _asarray(fixed["Phi_m"])
     Phi_mg = _asarray(fixed["Phi_mg"])

--- a/src/cw2017/models/conditionals.py
+++ b/src/cw2017/models/conditionals.py
@@ -59,6 +59,9 @@ def unpack_params3a_unconstrained(
     gamma1_free_2elts = vec[idx : idx + 2]
     idx += 2
 
+    mu_h_bar_raw = vec[idx : idx + Nh]
+    idx += Nh
+
     if idx != vec.size:
         raise ValueError("Unexpected vector length for Params3aUnconstrained")
 
@@ -72,6 +75,7 @@ def unpack_params3a_unconstrained(
         phiQ_sign_raw=phiQ_sign_raw,
         gamma0_last_raw=gamma0_last_raw,
         gamma1_free_2elts=gamma1_free_2elts,
+        mu_h_bar_raw=mu_h_bar_raw,
     )
 
 
@@ -90,6 +94,7 @@ def pack_params3a_unconstrained(
         jnp.atleast_1d(_asarray(u.phiQ_sign_raw)),
         jnp.atleast_1d(_asarray(u.gamma0_last_raw)),
         _asarray(u.gamma1_free_2elts).reshape(-1),
+        _asarray(u.mu_h_bar_raw).reshape(-1),
     ]
     return jnp.concatenate(parts, axis=0)
 

--- a/src/cw2017/models/parameters.py
+++ b/src/cw2017/models/parameters.py
@@ -29,6 +29,7 @@ class Params3aUnconstrained:
     phiQ_sign_raw: Array
     gamma0_last_raw: Array
     gamma1_free_2elts: Array
+    mu_h_bar_raw: Array
 
 
 @dataclass
@@ -51,6 +52,7 @@ class Params3a:
     phiQ_toprow: Array
     Gamma0: Array
     Gamma1: Array
+    mu_h_bar: Array
 
 
 def unit_lower_from_free(free_entries: Array) -> Array:
@@ -117,6 +119,8 @@ def constrain_params3a(
     Gamma1 = Gamma1.at[row_idx, cols - 2 : cols].set(jnp.asarray(u.gamma1_free_2elts, dtype=jnp.float64))
     Gamma1 = Gamma1.at[rows - 1, cols - 1].set(1200.0)
 
+    mu_h_bar = jnp.asarray(u.mu_h_bar_raw, dtype=jnp.float64)
+
     params = Params3a(
         Omega_diag=Omega_diag,
         L_g=L_g,
@@ -127,6 +131,7 @@ def constrain_params3a(
         phiQ_toprow=phiQ_toprow,
         Gamma0=Gamma0,
         Gamma1=Gamma1,
+        mu_h_bar=mu_h_bar,
     )
     return params, 0.0
 

--- a/src/cw2017/models/priors_3a.py
+++ b/src/cw2017/models/priors_3a.py
@@ -42,6 +42,9 @@ def logprior_3a(u: Params3aUnconstrained, cfg: Dict[str, float]) -> jnp.float64:
     sigma_gamma1 = cfg.get("sigma_gamma1", 250.0)
     gamma1_prior = jnp.sum(_normal_logpdf(u.gamma1_free_2elts, 0.0, sigma_gamma1))
 
+    sigma_mu_h = cfg.get("sigma_mu_h", 0.5)
+    mu_h_prior = jnp.sum(_normal_logpdf(u.mu_h_bar_raw, 0.0, sigma_mu_h))
+
     return (
         log_omega_prior
         + L_prior
@@ -53,6 +56,7 @@ def logprior_3a(u: Params3aUnconstrained, cfg: Dict[str, float]) -> jnp.float64:
         + phi13sign_prior
         + gamma0_prior
         + gamma1_prior
+        + mu_h_prior
     )
 
 

--- a/src/cw2017/samplers/gibbs.py
+++ b/src/cw2017/samplers/gibbs.py
@@ -31,7 +31,7 @@ def _param_dimension(info: Dict[str, int], maturities: Iterable[int]) -> int:
     Ng = int(info["Ng"])
     Nh = int(info["Nh"])
     qs_len = count_qs_entries(info)
-    return dy + 3 + (Nm + Ng) + Nh + qs_len + 3 + 1 + 1 + 2
+    return dy + 3 + (Nm + Ng) + Nh + qs_len + 3 + 1 + 1 + 2 + Nh
 
 
 def run_block3a_hmc_step(

--- a/tests/test_block3a_smoke.py
+++ b/tests/test_block3a_smoke.py
@@ -92,7 +92,7 @@ def block3a_setup():
     from cw2017.math.fill_q import count_qs_entries
 
     qs_len = count_qs_entries(info)
-    dim = dy + 3 + (info["Nm"] + info["Ng"]) + info["Nh"] + qs_len + 3 + 1 + 1 + 2
+    dim = dy + 3 + (info["Nm"] + info["Ng"]) + info["Nh"] + qs_len + 3 + 1 + 1 + 2 + info["Nh"]
     init_vec = jax.random.normal(u_key, (dim,), dtype=jnp.float64) * 0.01
 
     return rng, fixed, data, cfg, warmup_cfg, info, maturities, init_vec


### PR DESCRIPTION
## Summary
- add the long-run volatility mean to the block 3a HMC parameterisation and priors
- plumb the sampled volatility mean through the measurement builder and Kalman design so the SR-KF uses the updated value
- update the block 3a dimension bookkeeping and smoke test to cover the enlarged state

## Testing
- pytest tests/test_block3a_smoke.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d57f60acac83209b4a643a887e0591