### PR TITLE
Implement DK smoother block with equity constraint slack

### DIFF
--- a/src/hmc_gibbs/equity/constraints.py
+++ b/src/hmc_gibbs/equity/constraints.py
@@ -1,40 +1,123 @@
-"""Equity pricing linear constraints.
-
-TODOs:
-- populate θ matrices from Creal & Wu (2017) Appendix
-- implement solver respecting partitioned means between g and m blocks
-- add automatic differentiation tests verifying constraint Jacobians
-"""
+"""Equity pricing constraint utilities."""
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, NamedTuple
 
+import jax
 import jax.numpy as jnp
 
 from ..typing import Array
 
 
-def solve_linear_equity_constraint(params: Any, means: Array) -> Array:
-    """Apply the linear equity pricing constraint to the conditional means.
+class EquityConstraintSolution(NamedTuple):
+    """Result of enforcing the equity-pricing inequality."""
 
-    Parameters
-    ----------
-    params:
-        Placeholder parameter bundle that will eventually expose θ matrices and variance
-        terms required for the constraint.
-    means:
-        Array of conditional means prior to enforcing the restriction. The final
-        implementation will adjust one element to satisfy θ_m μ_m + θ_g μ_g = V.
+    means: jnp.ndarray
+    log_jacobian: jnp.float64
+    slack: jnp.float64
 
-    Returns
-    -------
-    Array
-        Means satisfying the placeholder constraint. Currently the function returns
-        ``means`` unchanged and serves as a hook for future development.
+
+def _get(mapping: Mapping[str, Any] | Any, name: str, default: Any = None) -> Any:
+    if isinstance(mapping, Mapping):
+        return mapping.get(name, default)
+    return getattr(mapping, name, default)
+
+
+def _softplus_tau(z: jnp.ndarray, temperature: jnp.ndarray) -> jnp.ndarray:
+    scaled = z / temperature
+    return temperature * jnp.log1p(jnp.exp(scaled))
+
+
+def _softplus_tau_prime(z: jnp.ndarray, temperature: jnp.ndarray) -> jnp.ndarray:
+    scaled = z / temperature
+    return jax.nn.sigmoid(scaled)
+
+
+def _ensure_slice(slices: Mapping[str, slice], key: str) -> slice:
+    sl = slices.get(key)
+    if sl is None:
+        raise KeyError(f"Missing slice for '{key}' in equity constraint parameters")
+    return sl
+
+
+def solve_linear_equity_constraint(params: Any, means: Array) -> EquityConstraintSolution:
+    """Apply the linear equity constraint using the slack reparameterisation.
+
+    The implementation mirrors the description in Section 3.3 of
+    ``docs/algorithm_overview`` while using the coefficient structure reported in
+    Section 1.3 of ``docs/model_writeup``.  We introduce a free scalar ``ζ`` and
+    map it through a temperature-controlled softplus to obtain a strictly
+    positive slack ``s`` that keeps the inequality
+
+    .. math::
+
+        \theta_m^\top \bar{\mu}_m + \theta_g^\top \bar{\mu}_g^u
+        + (\theta_g^{\mathbb{Q}})^\top \bar{\mu}_g^{\mathbb{Q},u} + V = -s
+
+    satisfied for every Gibbs iteration.  One element of
+    :math:`\bar{\mu}_g^{\mathbb{Q},u}` is treated as the pivot and solved for
+    analytically, yielding the Jacobian contribution that must be added to the log
+    posterior.
     """
 
-    return jnp.asarray(means, dtype=jnp.float64)
+    means_arr = jnp.asarray(means, dtype=jnp.float64)
+
+    slices = _get(params, "slices", {})
+    if not isinstance(slices, Mapping):
+        raise TypeError("`params` must expose a mapping `slices` with state partitions")
+
+    mu_m_slice = _ensure_slice(slices, "mu_m")
+    mu_gu_slice = _ensure_slice(slices, "mu_g_u")
+    mu_gq_slice = _ensure_slice(slices, "mu_gQ_u")
+
+    mu_m = means_arr[mu_m_slice]
+    mu_gu = means_arr[mu_gu_slice]
+    mu_gq = means_arr[mu_gq_slice]
+
+    theta_m = jnp.asarray(_get(params, "theta_m", jnp.zeros_like(mu_m)), dtype=jnp.float64)
+    theta_g = jnp.asarray(_get(params, "theta_g", jnp.zeros_like(mu_gu)), dtype=jnp.float64)
+    theta_gq = jnp.asarray(_get(params, "theta_g_q", jnp.zeros_like(mu_gq)), dtype=jnp.float64)
+    V = jnp.asarray(_get(params, "V", 0.0), dtype=jnp.float64)
+
+    pivot_rel = int(_get(params, "pivot_index", mu_gq.shape[0] - 1))
+    if pivot_rel < 0 or pivot_rel >= mu_gq.shape[0]:
+        raise IndexError("Pivot index for μ_g^{Q,u} is out of range")
+
+    temperature = jnp.clip(
+        jnp.asarray(_get(params, "slack_temperature", 1.0), dtype=jnp.float64),
+        0.5,
+        2.0,
+    )
+    zeta = jnp.asarray(_get(params, "slack_free", 0.0), dtype=jnp.float64)
+
+    slack = _softplus_tau(zeta, temperature)
+    theta_m_dot = jnp.dot(theta_m, mu_m) if mu_m.size else jnp.array(0.0, dtype=jnp.float64)
+    theta_g_dot = jnp.dot(theta_g, mu_gu) if mu_gu.size else jnp.array(0.0, dtype=jnp.float64)
+
+    pivot_coef = theta_gq[pivot_rel]
+    if not jnp.isfinite(pivot_coef) or jnp.abs(pivot_coef) < 1e-12:
+        raise ValueError("Pivot coefficient for μ_g^{Q,u} must be finite and non-zero")
+
+    idx = jnp.arange(mu_gq.shape[0])
+    mask = idx != pivot_rel
+    tail_coef = theta_gq[mask]
+    tail_mu = mu_gq[mask]
+    tail_contrib = jnp.dot(tail_coef, tail_mu) if tail_coef.size else jnp.array(0.0, dtype=jnp.float64)
+
+    numerator = -slack - theta_m_dot - theta_g_dot - tail_contrib - V
+    pivot_value = numerator / pivot_coef
+    mu_gq = mu_gq.at[pivot_rel].set(pivot_value)
+
+    jacobian_term = _softplus_tau_prime(zeta, temperature)
+    log_jac = jnp.log(jacobian_term) - jnp.log(jnp.abs(pivot_coef))
+
+    updated = means_arr.at[mu_m_slice].set(mu_m)
+    updated = updated.at[mu_gu_slice].set(mu_gu)
+    updated = updated.at[mu_gq_slice].set(mu_gq)
+
+    return EquityConstraintSolution(means=updated, log_jacobian=log_jac, slack=slack)
 
 
-__all__ = ["solve_linear_equity_constraint"]
+__all__ = ["solve_linear_equity_constraint", "EquityConstraintSolution"]

--- a/src/hmc_gibbs/kalman/smoother.py
+++ b/src/hmc_gibbs/kalman/smoother.py
@@ -1,29 +1,176 @@
-"""Durbin–Koopman simulation smoother scaffold.
+"""Durbin–Koopman simulation smoother for the :math:`g`-block.
 
-TODOs:
-- integrate with SR-KF outputs for backward sampling
-- incorporate disturbance smoothing for g-block draws
-- expose RNG controls for reproducible simulation smoothing
+The implementation follows the linear state-space specification described in
+Section 1.3 of ``docs/model_writeup`` and the Gibbs block construction outlined
+in Section 3.3 of ``docs/algorithm_overview``.  Conditioning on the current
+draws of :math:`h_t` and all structural parameters, we run the square-root
+Kalman filter forward pass and subsequently apply the Durbin–Koopman simulation
+smoother (Form I) to obtain a draw of the latent :math:`g_{1:T}` path together
+with updated long-run means :math:`(\bar{\mu}_m, \bar{\mu}_g^u,\bar{\mu}_g^{\mathbb{Q},u})`.
 """
 
 from __future__ import annotations
 
-from typing import Any, Tuple
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Tuple
 
 import jax
 import jax.numpy as jnp
 
+from kalman.ffbs import Step, dk_sample, kf_forward_sr_wrapper
+
 from ..typing import Array, PRNGKey
 
 
-def dk_simulation_smoother(params: Any, h_t: Array, y_t: Array, m_t: Array, key: PRNGKey) -> Tuple[Array, Array]:
-    """Stub for the Durbin–Koopman simulation smoother."""
+@dataclass(frozen=True)
+class StateSpaceSpec:
+    """Container describing the augmented state-space model.
 
-    key, noise_key = jax.random.split(key)
-    y_t = jnp.asarray(y_t, dtype=jnp.float64)
-    latent = jax.random.normal(noise_key, shape=y_t.shape, dtype=jnp.float64)
-    means = jnp.zeros_like(latent)
-    return latent, means
+    Attributes
+    ----------
+    steps:
+        Callable or sequence returning :class:`~kalman.ffbs.Step` instances for
+        each time period.
+    x0_mean, x0_cov:
+        Mean and covariance of the initial state.
+    slices:
+        Mapping exposing slices for the :math:`g` block and the static means.
+    """
+
+    steps: Iterable[Step] | Sequence[Step] | Any
+    x0_mean: Array
+    x0_cov: Array
+    slices: Dict[str, slice]
+
+
+def _as_array(x: Any) -> jnp.ndarray:
+    return jnp.asarray(x, dtype=jnp.float64)
+
+
+def _stack_observations(m_t: Array | None, y_t: Array | None, h_t: Array | None) -> jnp.ndarray:
+    """Stack observable blocks ``(m_t, y_t, h_t)`` into a single matrix."""
+
+    pieces = []
+    for block in (m_t, y_t, h_t):
+        if block is None:
+            continue
+        arr = _as_array(block)
+        if arr.ndim != 2:
+            raise ValueError("Each observation block must be two-dimensional")
+        pieces.append(arr)
+
+    if not pieces:
+        raise ValueError("At least one observation block is required")
+
+    obs = jnp.concatenate(pieces, axis=1)
+    return obs
+
+
+def _resolve_spec(params: Any, obs: jnp.ndarray, h_t: Array | None, m_t: Array | None) -> StateSpaceSpec:
+    """Return the state-space specification used by the simulation smoother."""
+
+    mapping: Mapping[str, Any] | None = None
+    if isinstance(params, Mapping):
+        mapping = params
+    elif hasattr(params, "__dict__"):
+        mapping = params.__dict__  # type: ignore[assignment]
+
+    spec_obj: Any = None
+    if mapping is not None:
+        if "state_space" in mapping:
+            spec_obj = mapping["state_space"]
+        elif "build_state_space" in mapping:
+            builder = mapping["build_state_space"]
+            spec_obj = builder(params=params, y_t=obs, h_t=h_t, m_t=m_t)
+    elif hasattr(params, "build_state_space"):
+        spec_obj = params.build_state_space(params=params, y_t=obs, h_t=h_t, m_t=m_t)
+
+    if spec_obj is None:
+        raise ValueError(
+            "A state-space specification with keys 'steps', 'x0_mean', 'x0_cov',"
+            " and 'slices' must be provided via `params`."
+        )
+
+    if isinstance(spec_obj, StateSpaceSpec):
+        return spec_obj
+
+    if isinstance(spec_obj, Mapping):
+        steps = spec_obj.get("steps")
+        x0_mean = spec_obj.get("x0_mean")
+        x0_cov = spec_obj.get("x0_cov")
+        slices = dict(spec_obj.get("slices", {}))
+    elif isinstance(spec_obj, tuple) and len(spec_obj) == 4:
+        steps, x0_mean, x0_cov, slices = spec_obj
+        slices = dict(slices)
+    else:
+        raise TypeError("Unsupported state-space specification format")
+
+    if steps is None or x0_mean is None or x0_cov is None:
+        raise ValueError("State-space specification is missing required fields")
+
+    return StateSpaceSpec(steps=steps, x0_mean=_as_array(x0_mean), x0_cov=_as_array(x0_cov), slices=slices)
+
+
+def _extract_means(sample: jnp.ndarray, slices: Dict[str, slice]) -> jnp.ndarray:
+    """Return the concatenated static means from the state trajectory."""
+
+    mu_m_slice = slices.get("mu_m", slice(0, 0))
+    mu_gu_slice = slices.get("mu_g_u", slice(mu_m_slice.stop, mu_m_slice.stop))
+    mu_gq_slice = slices.get("mu_gQ_u", slice(mu_gu_slice.stop, mu_gu_slice.stop))
+
+    def _slice(arr: jnp.ndarray, sl: slice) -> jnp.ndarray:
+        if sl.stop <= sl.start:
+            return jnp.asarray([], dtype=arr.dtype)
+        return arr[..., sl]
+
+    mu_m = _slice(sample, mu_m_slice)
+    mu_gu = _slice(sample, mu_gu_slice)
+    mu_gq = _slice(sample, mu_gq_slice)
+
+    return jnp.concatenate([mu_m, mu_gu, mu_gq], axis=-1)
+
+
+def dk_simulation_smoother(
+    params: Any,
+    h_t: Array,
+    y_t: Array,
+    m_t: Array,
+    key: PRNGKey,
+) -> Tuple[Array, jnp.ndarray]:
+    """Draw :math:`g_{1:T}` and the long-run means using the DK smoother."""
+
+    h_obs = _as_array(h_t) if h_t is not None else None
+    m_obs = _as_array(m_t) if m_t is not None else None
+    y_obs = _as_array(y_t) if y_t is not None else None
+
+    stacked_obs = _stack_observations(m_obs, y_obs, h_obs)
+    spec = _resolve_spec(params, stacked_obs, h_obs, m_obs)
+
+    cache = kf_forward_sr_wrapper(
+        stacked_obs,
+        spec.steps,
+        spec.x0_mean,
+        spec.x0_cov,
+        exact_tol=0.0,
+    )
+
+    g_slice = spec.slices.get("g", slice(0, 0))
+    key, draw_key = jax.random.split(key)
+    full_sample = dk_sample(draw_key, stacked_obs, spec.steps, spec.x0_mean, spec.x0_cov, cache)
+
+    if g_slice.stop <= g_slice.start:
+        raise ValueError("State-space specification must expose a non-empty 'g' slice")
+
+    g_sample = full_sample[:, g_slice]
+    static_slices = spec.slices.get("static_all")
+    if static_slices is not None and static_slices.stop > static_slices.start:
+        static_segment = full_sample[:, static_slices][-1]
+    else:
+        static_segment = full_sample[-1]
+
+    means = _extract_means(static_segment, spec.slices)
+    return g_sample, means
 
 
 __all__ = ["dk_simulation_smoother"]

--- a/src/hmc_gibbs/models/conditionals.py
+++ b/src/hmc_gibbs/models/conditionals.py
@@ -182,7 +182,9 @@ def logpost_block2_q_eigs(theta_block: Any, fixed: Dict[str, Any], data: Dict[st
     return jnp.where(jnp.isfinite(logpost), logpost, -jnp.inf)
 
 
-def draw_block2b_g_and_means(theta_block: Any, fixed: Dict[str, Any], data: Dict[str, Any]) -> Tuple[jnp.ndarray, jnp.ndarray]:
+def draw_block2b_g_and_means(
+    theta_block: Any, fixed: Dict[str, Any], data: Dict[str, Any]
+) -> Tuple[jnp.ndarray, equity_constraints.EquityConstraintSolution]:
     """Draw g and means using the Durbin–Koopman smoother and apply equity constraints."""
 
     work_logger.incr(kalman_evals=1)
@@ -193,8 +195,8 @@ def draw_block2b_g_and_means(theta_block: Any, fixed: Dict[str, Any], data: Dict
         m_t=data.get("m_t"),
         key=data.get("key"),
     )
-    constrained_means = equity_constraints.solve_linear_equity_constraint(theta_block, means)
-    return g_sample, constrained_means
+    solution = equity_constraints.solve_linear_equity_constraint(theta_block, means)
+    return g_sample, solution
 
 
 def pgibbs_h(theta_block: Any, fixed: Dict[str, Any], data: Dict[str, Any]) -> jnp.ndarray:

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -7,6 +7,8 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
+from kalman.ffbs import Step
+
 from hmc_gibbs.equity import constraints
 from hmc_gibbs.samplers.hmc_block import adapt_block_chees, hmc_block_step
 from hmc_gibbs.utils import jax_setup  # noqa: F401
@@ -16,17 +18,67 @@ def test_smoother_output_shapes() -> None:
     key = jax.random.PRNGKey(0)
     from hmc_gibbs.kalman import smoother  # imported lazily to avoid circular deps
 
+    T = 5
+    g_dim = 2
+    obs_dim = 6
+
+    steps = []
+    Z = jnp.zeros((obs_dim, g_dim), dtype=jnp.float64)
+    d = jnp.zeros((obs_dim,), dtype=jnp.float64)
+    H = jnp.eye(obs_dim, dtype=jnp.float64) * 0.05
+    T_mat = jnp.eye(g_dim, dtype=jnp.float64) * 0.95
+    c = jnp.zeros((g_dim,), dtype=jnp.float64)
+    R = jnp.eye(g_dim, dtype=jnp.float64)
+    Q = jnp.eye(g_dim, dtype=jnp.float64) * 0.1
+    for _ in range(T):
+        steps.append(Step(Z=Z, d=d, H=H, T=T_mat, c=c, R=R, Q=Q))
+
+    state_spec = {
+        "steps": steps,
+        "x0_mean": jnp.zeros((g_dim,), dtype=jnp.float64),
+        "x0_cov": jnp.eye(g_dim, dtype=jnp.float64),
+        "slices": {"g": slice(0, g_dim), "mu_m": slice(g_dim, g_dim), "mu_g_u": slice(g_dim, g_dim), "mu_gQ_u": slice(g_dim, g_dim)},
+    }
+
+    params = {"state_space": state_spec}
+
     g_sample, means = smoother.dk_simulation_smoother(
-        {}, jnp.zeros((5, 2)), jnp.zeros((5, 2)), jnp.zeros((5, 2)), key
+        params, jnp.zeros((T, 2)), jnp.zeros((T, 2)), jnp.zeros((T, 2)), key
     )
-    assert g_sample.shape == (5, 2)
-    assert means.shape == (5, 2)
+    assert g_sample.shape == (T, g_dim)
+    assert means.shape == (0,)
 
 
-def test_equity_constraint_identity() -> None:
-    means = jnp.ones((3,))
-    constrained = constraints.solve_linear_equity_constraint({}, means)
-    np.testing.assert_allclose(constrained, means)
+def test_equity_constraint_enforces_inequality() -> None:
+    means = jnp.array([0.1, -0.2, 0.3, 0.4, 0.5], dtype=jnp.float64)
+    params = {
+        "slices": {
+            "mu_m": slice(0, 2),
+            "mu_g_u": slice(2, 3),
+            "mu_gQ_u": slice(3, 5),
+        },
+        "theta_m": jnp.array([0.5, -0.25], dtype=jnp.float64),
+        "theta_g": jnp.array([0.3], dtype=jnp.float64),
+        "theta_g_q": jnp.array([0.4, -0.6], dtype=jnp.float64),
+        "V": 0.1,
+        "pivot_index": 1,
+        "slack_free": jnp.array(0.2, dtype=jnp.float64),
+    }
+
+    solution = constraints.solve_linear_equity_constraint(params, means)
+    updated = solution.means
+
+    mu_m = updated[params["slices"]["mu_m"]]
+    mu_gu = updated[params["slices"]["mu_g_u"]]
+    mu_gq = updated[params["slices"]["mu_gQ_u"]]
+
+    lhs = (
+        jnp.dot(params["theta_m"], mu_m)
+        + jnp.dot(params["theta_g"], mu_gu)
+        + jnp.dot(params["theta_g_q"], mu_gq)
+        + params["V"]
+    )
+    np.testing.assert_allclose(lhs, -solution.slack, rtol=1e-5, atol=1e-5)
 
 
 def test_hmc_block_adaptation_smoke() -> None:


### PR DESCRIPTION
## Summary
- implement a state-space driven Durbin–Koopman simulation smoother that samples g paths and long-run means while referencing the documented model structure
- add a slack-reparameterised equity constraint solver that enforces the inequality and returns Jacobian information for the Gibbs block
- update the Gibbs block wrapper and shape tests to accommodate the new solver API and cover the constraint logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5982a6b708320b0fcc9f7b9a4e5f1